### PR TITLE
feat/anon: add built-in anon & logged-in groups

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -125,6 +125,8 @@ that we send to the handler for our server. The `httptest.ResponseRecorder`
 stores the response information including `.Code` and `.Body` which can be
 returned as a string or bytes.
 
+### Example Test
+
 This is a basic pattern for a test to hit a server endpoint (in this example,
 sending some JSON in a `POST`):
 
@@ -169,3 +171,4 @@ coverage.
 ```
 make coverage-viz
 ```
+The `coverage.out` file can also be used with the usual go testing and coverage tools.

--- a/README.md
+++ b/README.md
@@ -58,13 +58,21 @@ createdb
 ./bin/arborist --port 8080 --jwks https://dev.planx-pla.net/user/well-known/.jwks
 ```
 
+### Building With Docker
+
 There is also the `Dockerfile` in the root directory which is used to build a
 Docker image for the server. In short, run this command from the root directory
 to build an image:
-```
+```bash
 docker build -t arborist .
 ```
-See also Docker documentation for more details on how to use Docker.
+Run the docker image:
+```bash
+docker run -p 8080:8080 arborist --port 8080 # plus other arguments
+```
+(This command exposes arborist on port 8080 in the docker image, and maps port
+8080 from the docker image onto 8080 on the host machine.) See also Docker
+documentation for more details on how to use Docker.
 
 ### Building From GitHub
 
@@ -98,7 +106,7 @@ to work around this, if you prefer to work with the code elsewhere in the
 filesystem, is to create a symlink from the desired location to wherever the
 repository lives under `$GOPATH`.
 
-## Overview, Terminology, and Definitions
+## Terminology and Definitions
 
 We will start from the lowest-level definitions, and work upwards.
 
@@ -115,75 +123,24 @@ We will start from the lowest-level definitions, and work upwards.
   (key-value pairs which restrict the context of the action).
 - *Role:* collections of permissions. Roles are uniquely identified by an ID
   field.
-- *Resources* are anything that should be access-controlled, organized like
+- *Resource:* anything that should be access-controlled, organized like
   directories of a filesystem. Resources are uniquely identifiable by their full
   path. Resources can have "child" resources (subdirectories, or
   sub-subdirectories etc., in the filesystem model), where access to one
   resource implies access to all the resources below it. A resource might be,
   for example, an entire project in a data commons, like
   `/projects/project-abc`.
-
-## Setup
-
-### Building From GitHub
-
-Clone/Build/Install all-in-one command:
-
-```bash
-go get -u github.com/uc-cdis/arborist
-```
-
-The cloned source code can be found under `$GOPATH`, usually `~/go/` if not set.
-In the source folder, you can run `go install` to rebuild the project. The
-executable can be found under `$GOPATH/bin/`, which you may want to add to your
-`$PATH` if not done yet.
+- *Policy:* combines a set of roles and resources together, with the meaning
+  that the policy allows access to use any of its roles on any of its resources.
+  Policies are granted to users and groups to give them access.
+- *Group:* a set of users. Groups can be granted their own policies; this gives
+  access to that policy for all users in the group.
 
 
-### Building From Source
+## Configuring Access
 
-If you have already checked out the repository locally, you can build the
-executable from there directly, which will include any local changes during
-development.
-
-Build the go code with this command, run from the root directory:
-```bash
-go build -o bin/arborist
-```
-
-Be aware that the source code must have been
-[cloned correctly](https://github.com/golang/go/wiki/GitHubCodeLayout) into
-`$GOPATH`, see also the previous section. `go build` will not work correctly if
-you cloned the repository outside of the location that `go` expects. One option
-to work around this, if you prefer to work with the code elsewhere in the
-filesystem, is to create a symlink from the desired location to wherever the
-repository lives under `$GOPATH`.
-
-### Building and Running a Docker Image
-
-Build the docker image for arborist:
-```bash
-# Run from root directory
-docker build -t arborist .
-```
-
-Run the docker image:
-```bash
-docker run -p 8080:8080 arborist --port 8080
-```
-(This command exposes arborist on port 8080 in the docker image, and maps port
-8080 from the docker image onto 8080 on the host machine.)
+TODO
 
 ## Development
 
-### Tests
-
-Run all the tests:
-```bash
-go test ./...
-```
-
-### Code Coverage
-
-Use `make coverage` to generate a `coverage.out` file which can be used with go
-testing and coverage tools. `make coverage-viz` will additionally open it using
-the go coverage tools to visualize line-by-line coverage.
+See [DEVELOP.md](./DEVELOP.md).

--- a/README.md
+++ b/README.md
@@ -136,10 +136,27 @@ We will start from the lowest-level definitions, and work upwards.
 - *Group:* a set of users. Groups can be granted their own policies; this gives
   access to that policy for all users in the group.
 
-
 ## Configuring Access
 
-TODO
+Ultimately, the flowchart for granting access to users goes something like the
+following:
+
+1. Create roles, resources, and policies to define access.
+2. One or more of the following:
+  - Using groups:
+    1. Grant a policy to a group (`/group/{group}/policy` endpoint).
+    2. Add users to the group (`/group/{group}/user` endpoint).
+    3. Users in the group now have access.
+  - For generic permissions which should be granted to all users (including
+    anonymous users, or only those who are logged in, i.e. have a JWT):
+    1. Grant a policy to the built-in `anonymous` and/or `logged-in` groups.
+       (`/group/anonymous/policy` and `/group/logged-in/policy` endpoints)
+    2. Now users even without a JWT have access using the policies granted to
+       the `anonymous` group, and all users with just a JWT have access to the
+       policies for the `logged-in` group.
+  - Specifying permissions for individual users directly:
+    1. Grant an individual user a policy (`/user/{username}/policy` endpoint).
+    2. Now that user has access.
 
 ## Development
 

--- a/arborist/group.go
+++ b/arborist/group.go
@@ -7,6 +7,9 @@ import (
 	"github.com/lib/pq"
 )
 
+const AnonymousGroup = "anonymous"
+const LoggedInGroup = "logged-in"
+
 type Group struct {
 	Name     string   `json:"name"`
 	Users    []string `json:"users"`
@@ -112,6 +115,9 @@ func (group *Group) createInDb(db *sqlx.DB) *ErrorResponse {
 }
 
 func (group *Group) deleteInDb(db *sqlx.DB) *ErrorResponse {
+	if group.Name == AnonymousGroup || group.Name == LoggedInGroup {
+		return newErrorResponse("can't delete built-in groups", 400, nil)
+	}
 	stmt := "DELETE FROM grp WHERE name = $1"
 	_, err := db.Exec(stmt, group.Name)
 	if err != nil {

--- a/arborist/user.go
+++ b/arborist/user.go
@@ -197,6 +197,9 @@ func revokeUserPolicyAll(db *sqlx.DB, username string) *ErrorResponse {
 }
 
 func addUserToGroup(db *sqlx.DB, username string, groupName string) *ErrorResponse {
+	if groupName == AnonymousGroup || groupName == LoggedInGroup {
+		return newErrorResponse("can't add users to built-in groups", 400, nil)
+	}
 	stmt := `
 		INSERT INTO usr_grp(usr_id, grp_id)
 		VALUES ((SELECT id FROM usr WHERE name = $1), (SELECT id FROM grp WHERE name = $2))


### PR DESCRIPTION
### New Features

- Add `anonymous` and `logged-in` groups which can be given their own policies (though they can't contain users). Policies granted to the anonymous group allow to all users, whether or not they have a token, and the ones granted to `logged-in` apply to all users with a JWT.

Also update the README a bit; there was a duplicated section that's removed now.