### PR TITLE
feat/bulk-auth: add multiple auth request support

### DIFF
--- a/arborist/auth.go
+++ b/arborist/auth.go
@@ -10,8 +10,9 @@ import (
 )
 
 type AuthRequestJSON struct {
-	User    AuthRequestJSON_User    `json:"user"`
-	Request AuthRequestJSON_Request `json:"request"`
+	User     AuthRequestJSON_User      `json:"user"`
+	Request  *AuthRequestJSON_Request  `json:"request"`
+	Requests []AuthRequestJSON_Request `json:"requests"`
 }
 
 type AuthRequestJSON_User struct {

--- a/arborist/resource.go
+++ b/arborist/resource.go
@@ -249,7 +249,6 @@ func (resource *ResourceIn) createRecursively(db *sqlx.DB) *ErrorResponse {
 	stmt := "INSERT INTO resource(path, description) VALUES ($1, $2)"
 	_, err = tx.Exec(stmt, path, resource.Description)
 	if err != nil {
-		fmt.Println(err)
 		// should add more checking here to guarantee the correct error
 		_ = tx.Rollback()
 		// this should only fail because the resource was not unique. return error

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -751,11 +751,18 @@ components:
             jwt:
               type: string
               description: >-
-                A JWT belonging to a user, as defined by RFC 7519. It must contain a
-                field `context.user.policies` listing the policies granted to the user.
+                A JWT belonging to a user, as defined by RFC 7519. It must
+                contain a field `context.user.policies` listing the policies
+                granted to the user.
               example: 'eyJhbGciOiJFUzI1NiIsImtpZCI6IjE2In0[...]'
         request:
           type: object
+          description: >-
+              The action and resource a user is trying to access. Instead of
+              `request` the API also accepts `requests` which should be an array
+              of these objects. When using `requests`, arborist will return true
+              if the user has access for every request in the list, though they
+              may be granted via different policies.
           properties:
             resource:
               type: string


### PR DESCRIPTION
Add support for sending multiple auth requests in one call to arborist, where multiple different policies can satisfy different requests sent.