### PR TITLE
feat(star): support `*` for service/method

### DIFF
--- a/arborist/auth.go
+++ b/arborist/auth.go
@@ -217,8 +217,8 @@ func authorize(request *AuthRequest) (*AuthResponse, error) {
 					SELECT 1 FROM policy_role
 					JOIN permission ON permission.role_id = policy_role.role_id
 					WHERE policy_role.policy_id = policies.policy_id
-					AND permission.service = $2
-					AND permission.method = $3
+					AND (permission.service = $2 OR permission.service = '*')
+					AND (permission.method = $3 OR permission.method = '*')
 				) AND (
 					$4 OR policies.policy_id IN (
 						SELECT id FROM policy


### PR DESCRIPTION
Support for `'*'` as service or method in roles.