### PR TITLE
feat(resource-by-tag): list authed resource tags

### DIFF
--- a/arborist/auth.go
+++ b/arborist/auth.go
@@ -307,8 +307,9 @@ func authorizedResources(db *sqlx.DB, request *AuthRequest) ([]ResourceFromQuery
 			SELECT
 				resource.id,
 				resource.name,
-				resource.description,
 				resource.path,
+				resource.tag,
+				resource.description,
 				array(
 					SELECT child.path
 					FROM resource AS child
@@ -340,8 +341,9 @@ func authorizedResources(db *sqlx.DB, request *AuthRequest) ([]ResourceFromQuery
 			SELECT
 				resource.id,
 				resource.name,
-				resource.description,
 				resource.path,
+				resource.tag,
+				resource.description,
 				array(
 					SELECT child.path
 					FROM resource AS child
@@ -373,8 +375,9 @@ func authorizedResources(db *sqlx.DB, request *AuthRequest) ([]ResourceFromQuery
 			SELECT
 				resource.id,
 				resource.name,
-				resource.description,
 				resource.path,
+				resource.tag,
+				resource.description,
 				array(
 					SELECT child.path
 					FROM resource AS child

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -482,16 +482,24 @@ func (server *Server) handleListAuthResources(w http.ResponseWriter, r *http.Req
 		resources = append(resources, resourceFromQuery.standardize())
 	}
 
-	resourcePaths := make([]string, len(resources))
-	for i := range resources {
-		resourcePaths[i] = resources[i].Path
+	useTags := false
+	_, ok := r.URL.Query()["tags"]
+	if ok {
+		useTags = true
 	}
 
 	response := struct {
 		Resources []string `json:"resources"`
-	}{
-		Resources: resourcePaths,
+	}{}
+	resultList := make([]string, len(resources))
+	for i := range resources {
+		if useTags {
+			resultList[i] = resources[i].Tag
+		} else {
+			resultList[i] = resources[i].Path
+		}
 	}
+	response.Resources = resultList
 
 	_ = jsonResponseFrom(response, http.StatusOK).write(w, r)
 }


### PR DESCRIPTION
### New Features

- Add QS parameter `?tags` for `/auth/resources` which will make it output tags instead of paths.

The `/user/{name}/resources` endpoint also supports this.