### PR TITLE
feat/resource-by-tag: list resources by path or tag

### DIFF
--- a/arborist/auth.go
+++ b/arborist/auth.go
@@ -307,8 +307,9 @@ func authorizedResources(db *sqlx.DB, request *AuthRequest) ([]ResourceFromQuery
 			SELECT
 				resource.id,
 				resource.name,
-				resource.description,
 				resource.path,
+				resource.tag,
+				resource.description,
 				array(
 					SELECT child.path
 					FROM resource AS child
@@ -340,8 +341,9 @@ func authorizedResources(db *sqlx.DB, request *AuthRequest) ([]ResourceFromQuery
 			SELECT
 				resource.id,
 				resource.name,
-				resource.description,
 				resource.path,
+				resource.tag,
+				resource.description,
 				array(
 					SELECT child.path
 					FROM resource AS child
@@ -373,8 +375,9 @@ func authorizedResources(db *sqlx.DB, request *AuthRequest) ([]ResourceFromQuery
 			SELECT
 				resource.id,
 				resource.name,
-				resource.description,
 				resource.path,
+				resource.tag,
+				resource.description,
 				array(
 					SELECT child.path
 					FROM resource AS child

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -482,16 +482,24 @@ func (server *Server) handleListAuthResources(w http.ResponseWriter, r *http.Req
 		resources = append(resources, resourceFromQuery.standardize())
 	}
 
-	resourcePaths := make([]string, len(resources))
-	for i := range resources {
-		resourcePaths[i] = resources[i].Path
+	useTags := false
+	_, ok := r.URL.Query()["tags"]
+	if ok {
+		useTags = true
 	}
 
 	response := struct {
 		Resources []string `json:"resources"`
-	}{
-		Resources: resourcePaths,
+	}{}
+	resultList := make([]string, len(resources))
+	for i := range resources {
+		if useTags {
+			resultList[i] = resources[i].Tag
+		} else {
+			resultList[i] = resources[i].Path
+		}
 	}
+	response.Resources = resultList
 
 	_ = jsonResponseFrom(response, http.StatusOK).write(w, r)
 }

--- a/arborist/server_test.go
+++ b/arborist/server_test.go
@@ -296,6 +296,22 @@ func TestServer(t *testing.T) {
 		}
 	}
 
+	getResourceWithPath := func(t *testing.T, path string) arborist.ResourceOut {
+		url := fmt.Sprintf("/resource%s", path)
+		w := httptest.NewRecorder()
+		req := newRequest("GET", url, nil)
+		handler.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			httpError(t, w, fmt.Sprintf("couldn't find resource %s", path))
+		}
+		result := arborist.ResourceOut{}
+		err := json.Unmarshal(w.Body.Bytes(), &result)
+		if err != nil {
+			httpError(t, w, "couldn't read response from resource get")
+		}
+		return result
+	}
+
 	createRoleBytes := func(t *testing.T, body []byte) {
 		w := httptest.NewRecorder()
 		req := newRequest("POST", "/role", bytes.NewBuffer(body))
@@ -2528,7 +2544,6 @@ func TestServer(t *testing.T) {
 				if w.Code != http.StatusOK {
 					httpError(t, w, "auth resources request failed")
 				}
-				// in this case, since the user has zero access yet, should be empty
 				result := struct {
 					Resources []string `json:"resources"`
 				}{}
@@ -2565,6 +2580,25 @@ func TestServer(t *testing.T) {
 				}
 				msg := fmt.Sprintf("got response body: %s", w.Body.String())
 				assert.Equal(t, []string{resourcePath}, result.Resources, msg)
+				// check the response returning tags is also correct
+				w = httptest.NewRecorder()
+				req = newRequest("POST", "/auth/resources?tags", bytes.NewBuffer(body))
+				handler.ServeHTTP(w, req)
+				if w.Code != http.StatusOK {
+					httpError(t, w, "auth resources request failed")
+				}
+				err = json.Unmarshal(w.Body.Bytes(), &result)
+				if err != nil {
+					httpError(t, w, "couldn't read response from auth resources")
+				}
+				msg = fmt.Sprintf("got response body: %s", w.Body.String())
+				assert.Equal(t, 1, len(result.Resources), msg)
+				if len(result.Resources) != 1 {
+					t.Fatal()
+				}
+				tag := result.Resources[0]
+				resource := getResourceWithPath(t, resourcePath)
+				assert.Equal(t, resource.Tag, tag, "mismatched tag from auth resources list")
 
 				t.Run("Policies", func(t *testing.T) {
 					w := httptest.NewRecorder()


### PR DESCRIPTION
### New Features

- Add QS parameter ?tags for /auth/resources which will make it output tags instead of paths.

The /user/{name}/resources endpoint also supports this.