### PR TITLE
fix(user-group-list): include logged-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ following:
        (`/group/anonymous/policy` and `/group/logged-in/policy` endpoints)
     2. Now users even without a JWT have access using the policies granted to
        the `anonymous` group, and all users with just a JWT have access to the
-       policies for the `logged-in` group.
+       policies for the `logged-in` group. (All users are implicitly considered
+       part of the `logged-in` group.)
   - Specifying permissions for individual users directly:
     1. Grant an individual user a policy (`/user/{username}/policy` endpoint).
     2. Now that user has access.

--- a/arborist/server_test.go
+++ b/arborist/server_test.go
@@ -1245,7 +1245,7 @@ func TestServer(t *testing.T) {
 			assert.Equal(t, username, result.Name, msg)
 			assert.Equal(t, userEmail, result.Email, msg)
 			assert.Equal(t, []string{}, result.Policies, msg)
-			assert.Equal(t, []string{}, result.Groups, msg)
+			assert.Equal(t, []string{arborist.LoggedInGroup}, result.Groups, msg)
 		})
 
 		// do some preliminary setup so we have a policy to work with

--- a/arborist/user.go
+++ b/arborist/user.go
@@ -60,6 +60,7 @@ func userWithName(db *sqlx.DB, name string) (*UserFromQuery, error) {
 		return nil, err
 	}
 	user := users[0]
+	user.Groups = append(user.Groups, LoggedInGroup)
 	return &user, nil
 }
 


### PR DESCRIPTION
### Improvements

- Include `logged-in` group by default in the list of groups for queried users.