### PR TITLE
fix/resource-response

### DIFF
--- a/arborist/server.go
+++ b/arborist/server.go
@@ -676,7 +676,14 @@ func (server *Server) handleResourceCreate(w http.ResponseWriter, r *http.Reques
 	out := resourceFromQuery.standardize()
 	if errResponse != nil {
 		server.logger.Info("not creating resource %s (%s), already exists", out.Path, out.Tag)
-		_ = jsonResponseFrom(out, 409).write(w, r)
+		result := struct {
+			Error  HTTPError    `json:"error"`
+			Exists *ResourceOut `json:"exists"`
+		}{
+			Error:  errResponse.HTTPError,
+			Exists: &out,
+		}
+		_ = jsonResponseFrom(result, 409).write(w, r)
 	} else {
 		server.logger.Info("created resource %s (%s)", out.Path, out.Tag)
 		result := struct {

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -673,6 +673,16 @@ func (server *Server) handleResourceCreate(w http.ResponseWriter, r *http.Reques
 		_ = errResponse.write(w, r)
 		return
 	}
+	if resourceFromQuery == nil {
+		msg := fmt.Sprintf(
+			"couldn't return resource for %s, but it may have been created OK",
+			resource.Path,
+		)
+		errResponse := newErrorResponse(msg, 500, &err)
+		errResponse.log.write(server.logger)
+		_ = errResponse.write(w, r)
+		return
+	}
 	out := resourceFromQuery.standardize()
 	if errResponse != nil {
 		server.logger.Info("not creating resource %s (%s), already exists", out.Path, out.Tag)


### PR DESCRIPTION
- [x] (merge https://github.com/uc-cdis/arborist/pull/77 first and rebase)

### Improvements

- Return the resource body on 409s from resource creation so the caller can still see the tag for the existing resource.