### PR TITLE
feat(resource-p): like mkdir -p for resources

### DIFF
--- a/arborist/resource.go
+++ b/arborist/resource.go
@@ -262,17 +262,13 @@ func (resource *ResourceIn) createInDb(tx *sqlx.Tx) *ErrorResponse {
 	return nil
 }
 
-func (resource *ResourceIn) fillOutName() {
+func (resource *ResourceIn) createRecursively(tx *sqlx.Tx) *ErrorResponse {
+	// arborist uses `/` for path separator; ltree in postgres uses `.`
+	path := formatPathForDb(resource.Path)
 	if resource.Name == "" {
 		segments := strings.Split(resource.Path, "/")
 		resource.Name = segments[len(segments)-1]
 	}
-}
-
-func (resource *ResourceIn) createRecursively(tx *sqlx.Tx) *ErrorResponse {
-	// arborist uses `/` for path separator; ltree in postgres uses `.`
-	path := formatPathForDb(resource.Path)
-	resource.fillOutName()
 	stmt := "INSERT INTO resource(path, description) VALUES ($1, $2)"
 	_, err := tx.Exec(stmt, path, resource.Description)
 	if err != nil {

--- a/arborist/server_test.go
+++ b/arborist/server_test.go
@@ -681,6 +681,28 @@ func TestServer(t *testing.T) {
 				}
 			})
 
+			t.Run("CreateParents", func(t *testing.T) {
+				w := httptest.NewRecorder()
+				body := []byte(`{
+					"path": "/parent/doesnt/exist",
+					"description": "we did it"
+				}`)
+				req := newRequest("POST", "/resource?p", bytes.NewBuffer(body))
+				handler.ServeHTTP(w, req)
+				if w.Code != http.StatusCreated {
+					httpError(t, w, "could't create resource with parents")
+				}
+				getResourceWithPath(t, "/parent")
+				getResourceWithPath(t, "/parent/doesnt")
+				resource := getResourceWithPath(t, "/parent/doesnt/exist")
+				assert.Equal(
+					t,
+					"we did it",
+					resource.Description,
+					"resource description doesn't match",
+				)
+			})
+
 			t.Run("RedundantSlashes", func(t *testing.T) {
 				createResourceBytes(t, []byte(`{"path": "/too"}`))
 				createResourceBytes(t, []byte(`{"path": "/too/many"}`))

--- a/arborist/server_test.go
+++ b/arborist/server_test.go
@@ -701,6 +701,16 @@ func TestServer(t *testing.T) {
 					resource.Description,
 					"resource description doesn't match",
 				)
+
+				t.Run("ParentsAlreadyExist", func(t *testing.T) {
+					w := httptest.NewRecorder()
+					body := []byte(`{"path": "/parent/doesnt/exist"}`)
+					req := newRequest("POST", "/resource?p", bytes.NewBuffer(body))
+					handler.ServeHTTP(w, req)
+					if w.Code != http.StatusConflict {
+						httpError(t, w, "expected conflict from creating resource again")
+					}
+				})
 			})
 
 			t.Run("RedundantSlashes", func(t *testing.T) {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -159,6 +159,16 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ResourceInput'
+      parameters:
+        - in: path
+          name: p
+          description: >-
+            Ordinarily arborist will return an error if parent resources of a
+            resource you're trying to create do not exist yet. If the `p`
+            parameter is included, it behaves like `mkdir -p` and creates all
+            parent resources as necessary.
+          type: integer
+          required: false
       responses:
         201:
           description: JSON representation of successfully-created resource


### PR DESCRIPTION
### New Features

- Add QS param `?p` to `POST /resource` which will make arborist create parent resources for your request if they didn't exist already.