### PR TITLE
fix(p-error): report parent resource invalid

### DIFF
--- a/arborist/resource.go
+++ b/arborist/resource.go
@@ -264,6 +264,10 @@ func (resource *ResourceIn) createInDb(tx *sqlx.Tx) *ErrorResponse {
 }
 
 func (resource *ResourceIn) createRecursively(tx *sqlx.Tx) *ErrorResponse {
+	errResponse := resource.validate()
+	if errResponse != nil {
+		return errResponse
+	}
 	// arborist uses `/` for path separator; ltree in postgres uses `.`
 	path := formatPathForDb(resource.Path)
 	stmt := "INSERT INTO resource(path, description) VALUES ($1, $2)"


### PR DESCRIPTION
- Fix bug where while using the `?p` flag on resource creation to also
  create parents, arborist would not report errors from parent resources
  for containing invalid characters.