### PR TITLE
fix(put-policy): add bkwd compat and deprecation plan for put policy

### DIFF
--- a/arborist/policy.go
+++ b/arborist/policy.go
@@ -36,6 +36,8 @@ func (policy *Policy) UnmarshalJSON(data []byte) error {
 
 	// delete fields which should be ignored in user input
 	delete(fields, "ID")
+	// uncomment this after 3.0.0 and lowercase the ID field in optionalFields too
+	// delete(fields, "id")
 
 	optionalFields := map[string]struct{}{
 		"ID":          struct{}{},

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -95,6 +95,8 @@ func (server *Server) MakeRouter(out io.Writer) http.Handler {
 
 	router.Handle("/policy", http.HandlerFunc(server.handlePolicyList)).Methods("GET")
 	router.Handle("/policy", http.HandlerFunc(server.parseJSON(server.handlePolicyCreate))).Methods("POST")
+	// delete this (PUT /policy) route after 3.0.0
+	router.Handle("/policy", http.HandlerFunc(server.parseJSON(server.handlePolicyOverwrite))).Methods("PUT")
 	router.Handle("/policy/{policyID}", http.HandlerFunc(server.parseJSON(server.handlePolicyOverwrite))).Methods("PUT")
 	router.Handle("/policy/{policyID}", http.HandlerFunc(server.handlePolicyRead)).Methods("GET")
 	router.Handle("/policy/{policyID}", http.HandlerFunc(server.handlePolicyDelete)).Methods("DELETE")
@@ -589,7 +591,8 @@ func (server *Server) handlePolicyCreate(w http.ResponseWriter, r *http.Request,
 
 func (server *Server) handlePolicyOverwrite(w http.ResponseWriter, r *http.Request, body []byte) {
 	policy := &Policy{}
-	policy.Name = mux.Vars(r)["policyID"]
+	// uncomment this after 3.0.0
+	// policy.Name = mux.Vars(r)["policyID"]
 	err := json.Unmarshal(body, policy)
 	if err != nil {
 		msg := fmt.Sprintf("could not parse policy from JSON: %s", err.Error())


### PR DESCRIPTION
Note base branch

The desired behavior is to have Arborist have only `PUT /policy/{policyID}` and get the policy id from the URL and ignore the id field in the policy json if it is present. 

This PR adds backwards compatibility for the old version, `PUT /policy`. 
The intention is to remove the old version in 3.0.0. 



### Improvements
add backwards compatibility for PUT /policy/policyid

