### PR TITLE
fix(put-policy): update policy without delete-create

### DIFF
--- a/arborist/policy.go
+++ b/arborist/policy.go
@@ -34,12 +34,7 @@ func (policy *Policy) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// delete fields which should be ignored in user input
-	// (this deletes from `fields` map, so only affects validation)
-	delete(fields, "id")
-
 	optionalFields := map[string]struct{}{
-		"id":          struct{}{},
 		"description": struct{}{},
 	}
 	err = validateJSON("policy", policy, fields, optionalFields)
@@ -168,6 +163,9 @@ func (policy *Policy) roles(tx *sqlx.Tx) ([]RoleFromQuery, error) {
 // looking at the database. This includes that the policy must contain at least
 // one resource and at least one role.
 func (policy *Policy) validate() *ErrorResponse {
+	if len(policy.Name) == 0 {
+		return newErrorResponse("policy name cannot be empty string", 400, nil)
+	}
 	// Resources and roles must be non-empty
 	if len(policy.ResourcePaths) == 0 {
 		return newErrorResponse("no resource paths specified", 400, nil)

--- a/arborist/policy.go
+++ b/arborist/policy.go
@@ -35,7 +35,11 @@ func (policy *Policy) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// id is optional here because PUT doesn't require it to be in the json;
+	// handlePolicyOverwrite will populate id later, from the URL.
+	// id is still validated later, in policy `validate` function.
 	optionalFields := map[string]struct{}{
+		"id": struct{}{},
 		"description": struct{}{},
 	}
 	err = validateJSON("policy", policy, fields, optionalFields)
@@ -165,7 +169,7 @@ func (policy *Policy) roles(tx *sqlx.Tx) ([]RoleFromQuery, error) {
 // one resource and at least one role.
 func (policy *Policy) validate() *ErrorResponse {
 	if len(policy.Name) == 0 {
-		return newErrorResponse("policy name cannot be empty string", 400, nil)
+		return newErrorResponse("policy ID cannot be absent or empty", 400, nil)
 	}
 	// Resources and roles must be non-empty
 	if len(policy.ResourcePaths) == 0 {

--- a/arborist/policy.go
+++ b/arborist/policy.go
@@ -176,7 +176,6 @@ func (policy *Policy) validate() *ErrorResponse {
 	return nil
 }
 
-
 // add_resources_and_roles takes a policy and links it in the database
 // to each of its resources and roles.
 func (policy *Policy) add_resources_and_roles(tx *sqlx.Tx) *ErrorResponse {
@@ -280,7 +279,7 @@ func (policy *Policy) createInDb(tx *sqlx.Tx) *ErrorResponse {
 		return newErrorResponse(msg, 409, &err)
 	}
 
-        errResponse = policy.add_resources_and_roles(tx)
+	errResponse = policy.add_resources_and_roles(tx)
 	if errResponse != nil {
 		return errResponse
 	}
@@ -336,8 +335,8 @@ func (policy *Policy) updateInDb(tx *sqlx.Tx) *ErrorResponse {
 		return newErrorResponse(msg, 500, &err)
 	}
 
-        // Now add the new resources and roles
-        errResponse = policy.add_resources_and_roles(tx)
+	// Now add the new resources and roles
+	errResponse = policy.add_resources_and_roles(tx)
 	if errResponse != nil {
 		return errResponse
 	}

--- a/arborist/policy.go
+++ b/arborist/policy.go
@@ -35,12 +35,11 @@ func (policy *Policy) UnmarshalJSON(data []byte) error {
 	}
 
 	// delete fields which should be ignored in user input
-	delete(fields, "ID")
-	// uncomment this after 3.0.0 and lowercase the ID field in optionalFields too
-	// delete(fields, "id")
+	// (this deletes from `fields` map, so only affects validation)
+	delete(fields, "id")
 
 	optionalFields := map[string]struct{}{
-		"ID":          struct{}{},
+		"id":          struct{}{},
 		"description": struct{}{},
 	}
 	err = validateJSON("policy", policy, fields, optionalFields)

--- a/arborist/policy.go
+++ b/arborist/policy.go
@@ -304,6 +304,14 @@ func (policy *Policy) updateInDb(tx *sqlx.Tx) *ErrorResponse {
 		return newErrorResponse(msg, 404, &err)
 	}
 
+	stmt = "UPDATE policy SET description = $1 WHERE id = $2"
+	_, err = tx.Exec(stmt, policy.Description, policyID)
+	if err != nil {
+		_ = tx.Rollback()
+		msg := fmt.Sprintf("failed to update policy: update description failed: %s", err.Error())
+		return newErrorResponse(msg, 500, &err)
+	}
+
 	// First delete resources and roles that were previously attached to policy
 	stmt = "DELETE FROM policy_resource WHERE policy_id = $1"
 	_, err = tx.Exec(stmt, policyID)

--- a/arborist/resource.go
+++ b/arborist/resource.go
@@ -147,10 +147,10 @@ func (resourceFromQuery *ResourceFromQuery) standardize() ResourceOut {
 	return resource
 }
 
-// FormatPathForDb takes a path from a resource in the database and transforms
-// it to the front-end version of the resource path. Inverse of `formatDbPath`.
+// FormatPathForDb takes a front-end version of a resource path and transforms
+// it to its database version. Inverse of `formatDbPath`.
 //
-//     formatDbPath("/a/b/c") == "a.b.c"
+//     FormatPathForDb("/a/b/c") == "a.b.c"
 func FormatPathForDb(path string) string {
 	// -1 means replace everything
 	result := strings.TrimLeft(strings.Replace(UnderscoreEncode(path), "/", ".", -1), ".")

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -605,7 +605,7 @@ func (server *Server) handlePolicyOverwrite(w http.ResponseWriter, r *http.Reque
 	if mux.Vars(r)["policyID"] != "" {
 		policy.Name = mux.Vars(r)["policyID"]
 	}
-	errResponse := transactify(server.db, policy.overwriteInDb)
+	errResponse := transactify(server.db, policy.updateInDb)
 	if errResponse != nil {
 		errResponse.log.write(server.logger)
 		_ = errResponse.write(w, r)


### PR DESCRIPTION
Previously Arborist's PUT policy endpoint would just delete and (re)create a policy. But this changed the policy's pkey in the db, which breaks links in `[usr, grp, client]_policy`. New PUT policy handler will just delete the relevant entries in the `policy_[resource, role]` tables and make new ones. 

Additionally this PR: 
1. Overwrites policy name in json with policy name from URL _after_ unmarshaling is done, to correctly prefer the name from the URL 

Expected behavior post-Arborist 3.0.0: 
- `PUT /policy` endpoint deprecated and only `PUT /policy/{policyID}` used
- get policy name from url and ignore `id` field from request json if given

Behavior in the meantime (2.x.x): 
- Both `PUT /policy` and `PUT /policy/{policyID}` supported
- If policy name in url, then overwrite policy name in request json, if latter is present; if policy name not in url, then use policy name from request json. 


### Bug Fixes
- fix PUT policy behavior so that it does not unexpectedly remove usr/grp/client-policy relationships
- lowercase id field name in unmarshalJSON's optional fields
- validate id field in policy validate fn (error if policy id not in policy json or is empty string)
- overwrite policy name from json if policy name was present in url (overwrite should be done after unmarshal, not before)

