### PR TITLE
chore(authz): set authz_provider in migration

### DIFF
--- a/migrations/2019-09-03T155025Z_authz_provider/up.sql
+++ b/migrations/2019-09-03T155025Z_authz_provider/up.sql
@@ -4,3 +4,9 @@ ALTER TABLE usr_policy ADD COLUMN authz_provider VARCHAR;
 ALTER TABLE usr_grp ADD COLUMN authz_provider VARCHAR;
 ALTER TABLE grp_policy ADD COLUMN authz_provider VARCHAR;
 ALTER TABLE client_policy ADD COLUMN authz_provider VARCHAR;
+
+-- assuming all commons are only running user sync as AuthZ provider
+UPDATE usr_grp SET authz_provider = 'user-sync' WHERE authz_provider is NULL;
+UPDATE usr_policy SET authz_provider = 'user-sync' WHERE authz_provider is NULL;
+UPDATE grp_policy SET authz_provider = 'user-sync' WHERE authz_provider is NULL;
+UPDATE client_policy SET authz_provider = 'user-sync' WHERE authz_provider is NULL;


### PR DESCRIPTION
Will do nothing for Arborist 2.3 -> 2.3.1, assuming 2.3 is already taken care of manually.

### Deployment changes
- Assuming any commons running Arborist < 2.3 was using user sync only as AuthZ provider