### PR TITLE
add anon and logged in policies to /auth/resources

### DIFF
--- a/arborist/auth.go
+++ b/arborist/auth.go
@@ -512,6 +512,11 @@ func authorizedResources(db *sqlx.DB, request *AuthRequest) ([]ResourceFromQuery
 				JOIN usr_grp ON usr_grp.grp_id = grp.id
 				JOIN usr ON usr.id = usr_grp.usr_id
 				WHERE usr.name = $1
+				UNION
+				SELECT grp_policy.policy_id
+				FROM grp
+				JOIN grp_policy ON grp_policy.grp_id = grp.id
+				WHERE grp.name = 'anonymous' OR grp.name = 'logged-in'
 			) policies
 			INNER JOIN policy_resource ON policy_resource.policy_id = policies.policy_id
 			INNER JOIN resource AS roots ON roots.id = policy_resource.resource_id


### PR DESCRIPTION
### New Features

the (misleadingly named) 'anonymous' and 'logged-in' user groups' policies should apply to all logged-in users; /auth/mapping already includes this; make /auth/resources do the same
