### PR TITLE
(PXP-4696) Fix anonymous and all_users groups

### DIFF
--- a/arborist/auth.go
+++ b/arborist/auth.go
@@ -427,6 +427,12 @@ func authRequestFromGET(decode func(string, []string) (*TokenInfo, error), r *ht
 	return &authRequest, nil
 }
 
+// authorizedResouces returns the resources that are accessible (with any action)
+// to the username in AuthRequest. This includes the resources accessible to the
+// `anonymous` and `logged-in` groups. If the username in AuthRequest does not exist
+// in the db, this this function will NOT throw an error, but will return only
+// the resources accessible to the `anonymous` and `logged-in` groups.
+//
 // See the FIXME inside. Be careful how this is called, until the implementation is updated.
 func authorizedResources(db *sqlx.DB, request *AuthRequest) ([]ResourceFromQuery, *ErrorResponse) {
 	// if policies are specified in the request, we can use those (simplest query).
@@ -574,6 +580,8 @@ func authorizedResources(db *sqlx.DB, request *AuthRequest) ([]ResourceFromQuery
 	}
 }
 
+// authorizedResoucesForGroups returns the resources that are accessible (with any action)
+// to these groups.
 func authorizedResourcesForGroups(db *sqlx.DB, groups ...string) ([]ResourceFromQuery, *ErrorResponse) {
 	resources := []ResourceFromQuery{}
 	stmt := `

--- a/arborist/auth.go
+++ b/arborist/auth.go
@@ -486,6 +486,9 @@ func authorizedResources(db *sqlx.DB, request *AuthRequest) ([]ResourceFromQuery
 	}
 	resources := []ResourceFromQuery{}
 	if request.ClientID == "" {
+		if request.Username == "" {
+			return nil, newErrorResponse("missing username in auth request", 400, nil)
+		}
 		// alternative: SELECT DISTINCT * FROM resource WHERE resource.path <@ ARRAY(SELECT resource.path FROM (SELECT usr_policy.policy_id FROM usr JOIN usr_policy ON usr.id = usr_policy.usr_id WHERE usr.name = $1) policies INNER JOIN policy_resource ON policy_resource.policy_id = policies.policy_id INNER JOIN resource ON resource.id = policy_resource.resource_id);
 		stmt := `
 			SELECT DISTINCT

--- a/arborist/auth.go
+++ b/arborist/auth.go
@@ -402,9 +402,6 @@ func authRequestFromGET(decode func(string, []string) (*TokenInfo, error), r *ht
 		method = methodQS[0]
 	}
 	// get JWT from auth header and decode it
-	// If no request, pass a nil authRequest to makeAuthResourcesResponse.
-	// This indicates that there is no username provided, i.e. that server should
-	// return only anonymous resources. (See docs/username.md for more details.)
 	authHeader := r.Header.Get("Authorization")
 	if authHeader == "" {
 		msg := "auth request missing auth header"
@@ -463,7 +460,6 @@ func authorizedResources(db *sqlx.DB, request *AuthRequest) ([]ResourceFromQuery
 		`
 		err := db.Select(&resources, stmt)
 		if err != nil {
-			fmt.Printf("DEBUG DEBUG DEBUG aaah %v\n", err)
 			errResponse := newErrorResponse(
 				"resources query (using no username) failed",
 				500,
@@ -509,7 +505,6 @@ func authorizedResources(db *sqlx.DB, request *AuthRequest) ([]ResourceFromQuery
 		`
 		err = db.Select(&resources, stmt)
 		if err != nil {
-			fmt.Printf("DEBUG DEBUG DEBUG aaah %v\n", err)
 			errResponse := newErrorResponse(
 				"resources query (using no username) failed",
 				500,

--- a/arborist/auth.go
+++ b/arborist/auth.go
@@ -427,7 +427,7 @@ func authRequestFromGET(decode func(string, []string) (*TokenInfo, error), r *ht
 	return &authRequest, nil
 }
 
-// authorizedResouces returns the resources that are accessible (with any action)
+// authorizedResources returns the resources that are accessible (with any action)
 // to the username in AuthRequest. This includes the resources accessible to the
 // `anonymous` and `logged-in` groups. If the username in AuthRequest does not exist
 // in the db, this this function will NOT throw an error, but will return only
@@ -580,7 +580,7 @@ func authorizedResources(db *sqlx.DB, request *AuthRequest) ([]ResourceFromQuery
 	}
 }
 
-// authorizedResoucesForGroups returns the resources that are accessible (with any action)
+// authorizedResourcesForGroups returns the resources that are accessible (with any action)
 // to these groups.
 func authorizedResourcesForGroups(db *sqlx.DB, groups ...string) ([]ResourceFromQuery, *ErrorResponse) {
 	resources := []ResourceFromQuery{}

--- a/arborist/auth.go
+++ b/arborist/auth.go
@@ -486,9 +486,6 @@ func authorizedResources(db *sqlx.DB, request *AuthRequest) ([]ResourceFromQuery
 	}
 	resources := []ResourceFromQuery{}
 	if request.ClientID == "" {
-		if request.Username == "" {
-			return nil, newErrorResponse("missing username in auth request", 400, nil)
-		}
 		// alternative: SELECT DISTINCT * FROM resource WHERE resource.path <@ ARRAY(SELECT resource.path FROM (SELECT usr_policy.policy_id FROM usr JOIN usr_policy ON usr.id = usr_policy.usr_id WHERE usr.name = $1) policies INNER JOIN policy_resource ON policy_resource.policy_id = policies.policy_id INNER JOIN resource ON resource.id = policy_resource.resource_id);
 		stmt := `
 			SELECT DISTINCT

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -260,6 +260,11 @@ func (server *Server) handleAuthMappingPOST(w http.ResponseWriter, r *http.Reque
 		server.logger.Info("tried to handle auth mapping request but input was invalid: %s", msg)
 		errResponse = newErrorResponse(msg, 400, nil)
 	}
+	if requestBody.Username == "" {
+		msg := "missing `username` argument"
+		server.logger.Info(msg)
+		errResponse = newErrorResponse(msg, 400, nil)
+	}
 	if errResponse != nil {
 		_ = errResponse.write(w, r)
 		return

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -250,32 +250,42 @@ func (server *Server) handleAuthMappingGET(w http.ResponseWriter, r *http.Reques
 }
 
 func (server *Server) handleAuthMappingPOST(w http.ResponseWriter, r *http.Request, body []byte) {
-	var errResponse *ErrorResponse = nil
-	requestBody := struct {
-		Username string `json:"username"`
-	}{}
-	err := json.Unmarshal(body, &requestBody)
-	if err != nil {
-		msg := fmt.Sprintf("could not parse JSON: %s", err.Error())
-		server.logger.Info("tried to handle auth mapping request but input was invalid: %s", msg)
-		errResponse = newErrorResponse(msg, 400, nil)
+	// if receive empty body, call `authMapping` with an empty username.
+	// (See docs/username.md for more detail.)
+	if len(body) == 0 {
+		var errResponse *ErrorResponse = nil
+		emptyUsername := ""
+		mappings, errResponse := authMapping(server.db, emptyUsername)
+		if errResponse != nil {
+			errResponse.log.write(server.logger)
+			_ = errResponse.write(w, r)
+			return
+		}
+		_ = jsonResponseFrom(mappings, http.StatusOK).write(w, r)
+
+	} else {
+		var errResponse *ErrorResponse = nil
+		requestBody := struct {
+			Username string `json:"username"`
+		}{}
+		err := json.Unmarshal(body, &requestBody)
+		if err != nil {
+			msg := fmt.Sprintf("could not parse JSON: %s", err.Error())
+			server.logger.Info("tried to handle auth mapping request but input was invalid: %s", msg)
+			errResponse = newErrorResponse(msg, 400, nil)
+		}
+		if errResponse != nil {
+			_ = errResponse.write(w, r)
+			return
+		}
+		mappings, errResponse := authMapping(server.db, requestBody.Username)
+		if errResponse != nil {
+			errResponse.log.write(server.logger)
+			_ = errResponse.write(w, r)
+			return
+		}
+		_ = jsonResponseFrom(mappings, http.StatusOK).write(w, r)
 	}
-	if requestBody.Username == "" {
-		msg := "missing `username` argument"
-		server.logger.Info(msg)
-		errResponse = newErrorResponse(msg, 400, nil)
-	}
-	if errResponse != nil {
-		_ = errResponse.write(w, r)
-		return
-	}
-	mappings, errResponse := authMapping(server.db, requestBody.Username)
-	if errResponse != nil {
-		errResponse.log.write(server.logger)
-		_ = errResponse.write(w, r)
-		return
-	}
-	_ = jsonResponseFrom(mappings, http.StatusOK).write(w, r)
 }
 
 func (server *Server) handleAuthProxy(w http.ResponseWriter, r *http.Request) {

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -492,12 +492,12 @@ func (server *Server) handleListAuthResourcesGET(w http.ResponseWriter, r *http.
 	usernameInJWT := false
 	if hasJWT {
 		authRequest, errResponse = authRequestFromGET(server.decodeToken, r)
-		usernameInJWT = authRequest.Username != ""
 		if errResponse != nil {
 			errResponse.log.write(server.logger)
 			_ = errResponse.write(w, r)
 			return
 		}
+		usernameInJWT = authRequest.Username != ""
 	}
 
 	if hasJWT && usernameInJWT {

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -250,42 +250,27 @@ func (server *Server) handleAuthMappingGET(w http.ResponseWriter, r *http.Reques
 }
 
 func (server *Server) handleAuthMappingPOST(w http.ResponseWriter, r *http.Request, body []byte) {
-	// if receive empty body, call `authMapping` with an empty username.
-	// (See docs/username.md for more detail.)
-	if len(body) == 0 {
-		var errResponse *ErrorResponse = nil
-		emptyUsername := ""
-		mappings, errResponse := authMapping(server.db, emptyUsername)
-		if errResponse != nil {
-			errResponse.log.write(server.logger)
-			_ = errResponse.write(w, r)
-			return
-		}
-		_ = jsonResponseFrom(mappings, http.StatusOK).write(w, r)
-
-	} else {
-		var errResponse *ErrorResponse = nil
-		requestBody := struct {
-			Username string `json:"username"`
-		}{}
-		err := json.Unmarshal(body, &requestBody)
-		if err != nil {
-			msg := fmt.Sprintf("could not parse JSON: %s", err.Error())
-			server.logger.Info("tried to handle auth mapping request but input was invalid: %s", msg)
-			errResponse = newErrorResponse(msg, 400, nil)
-		}
-		if errResponse != nil {
-			_ = errResponse.write(w, r)
-			return
-		}
-		mappings, errResponse := authMapping(server.db, requestBody.Username)
-		if errResponse != nil {
-			errResponse.log.write(server.logger)
-			_ = errResponse.write(w, r)
-			return
-		}
-		_ = jsonResponseFrom(mappings, http.StatusOK).write(w, r)
+	var errResponse *ErrorResponse = nil
+	requestBody := struct {
+		Username string `json:"username"`
+	}{}
+	err := json.Unmarshal(body, &requestBody)
+	if err != nil {
+		msg := fmt.Sprintf("could not parse JSON: %s", err.Error())
+		server.logger.Info("tried to handle auth mapping request but input was invalid: %s", msg)
+		errResponse = newErrorResponse(msg, 400, nil)
 	}
+	if errResponse != nil {
+		_ = errResponse.write(w, r)
+		return
+	}
+	mappings, errResponse := authMapping(server.db, requestBody.Username)
+	if errResponse != nil {
+		errResponse.log.write(server.logger)
+		_ = errResponse.write(w, r)
+		return
+	}
+	_ = jsonResponseFrom(mappings, http.StatusOK).write(w, r)
 }
 
 func (server *Server) handleAuthProxy(w http.ResponseWriter, r *http.Request) {

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -478,6 +478,15 @@ func (server *Server) handleAuthRequest(w http.ResponseWriter, r *http.Request, 
 func (server *Server) handleListAuthResourcesGET(w http.ResponseWriter, r *http.Request) {
 	authRequest := &AuthRequest{}
 	var errResponse *ErrorResponse
+	// If no JWT is provided, pass a nil authRequest to makeAuthResourcesResponse.
+	// This indicates that there is no username provided, i.e. that server should
+	// return only anonymous resources. (See docs/username.md for more details.)
+	noJWT := r.Header.Get("Authorization") == ""
+	if noJWT {
+		authRequest = nil
+		server.makeAuthResourcesResponse(w, r, authRequest, errResponse)
+		return
+	}
 	authRequest, errResponse = authRequestFromGET(server.decodeToken, r)
 	if errResponse != nil {
 		errResponse.log.write(server.logger)

--- a/arborist/user.go
+++ b/arborist/user.go
@@ -80,6 +80,18 @@ func (userFromQuery *UserFromQuery) standardize() User {
 }
 
 func userWithName(db *sqlx.DB, name string) (*UserFromQuery, error) {
+	// NOTE @mpingram 2019-12-11: An explanation of the user's policies and their expiration
+	// dates returned from this query.
+	// The user's policies can come from three different sources, and policies from different
+	// sources expire in different ways:
+	// 1. Policies granted to the user:
+	// 		- Policies granted to the user have an expiration date (`usr_policy.expires_at`).
+	// 2. Policies in user's groups:
+	//		- Policies granted to groups the user is a member of expire when the user's membership
+	// 		in that group expires (`usr_group.expires_at`).
+	// 3. Polcies granted to the Anonymous and LoggedIn groups:
+	// 		- Membership in the built-in groups does not expire. We use expires_at = NULL to represent
+	// 		'no expiration for this policy'.
 	stmt := `
 		SELECT
 			usr.id,

--- a/arborist/user.go
+++ b/arborist/user.go
@@ -89,7 +89,7 @@ func userWithName(db *sqlx.DB, name string) (*UserFromQuery, error) {
 	// 2. Policies in user's groups:
 	//		- Policies granted to groups the user is a member of expire when the user's membership
 	// 		in that group expires (`usr_group.expires_at`).
-	// 3. Polcies granted to the Anonymous and LoggedIn groups:
+	// 3. Policies granted to the Anonymous and LoggedIn groups:
 	// 		- Membership in the built-in groups does not expire. We use expires_at = NULL to represent
 	// 		'no expiration for this policy'.
 	stmt := `

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -168,7 +168,7 @@ paths:
         this endpoint returns ONLY the resources available to members of the `anonymous` group.
 
 
-        If the `?tags` query string parameter is passed, this endpoint returns the resource
+        If the `tags` query string parameter is passed, this endpoint returns the resource
         tags for the resources, not the resources themselves.
       parameters:
         - in: header
@@ -212,7 +212,7 @@ paths:
         ONLY the resources available to members of the `anonymous` and `logged-in` groups.
 
 
-        If the `?tags` query string parameter is passed, this endpoint returns the resource
+        If the `tags` query string parameter is passed, this endpoint returns the resource
         tags for the resources, not the resources themselves.
       parameters:
         - in: query

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Arborist
-  version: 1.1.1
+  version: 2.3.2
   description: authorization microservice to handle ABAC based on configured policies
   license:
     name: 'Apache 2.0'
@@ -22,14 +22,36 @@ paths:
         - auth
       description: >-
         Return a mapping from the resources the specified user can access, to
-        the actions which they are authorized for on those resources.
+        the actions which they are authorized for on those resources. This includes
+        the mappings available to members of the `anonymous` and `logged-in` groups, 
+        which apply to all users (anonymous) and to all logged-in users (logged-in). 
+
+
+        This endpoint accepts either a username in the query string or a username
+        in a token in the Authorization header. If no username is provided in the query
+        string, the endpoint will use the username in the token in the Authorization
+        header.
+
+
+        If the specified user is not recognized by arborist, this endpoint returns
+        ONLY the mappings available to members of the `anonymous` and `logged-in` groups.
+
+
+        If no username is provided (i.e., if there is no username passed in the query
+        string AND no token is provided in the Authorization header), this endpoint returns ONLY the mappings 
+        available to members of the `anonymous` group.
       parameters:
         - in: query
           name: username
           schema:
             type: string
-          required: true
+          required: false
           description: the username in arborist to return results for
+        - in: header
+          name: Authorization
+          schema:
+            type: string
+          required: false
       responses:
         200:
           description: successful response
@@ -40,20 +62,28 @@ paths:
                   map from resource paths as keys, to lists of actions
                 type: object
                 example: {"/programs/DEV": [{"service": "*", "method": "read"}, {"service": "*", "method": "read-storage"}]}
-        400:
+        401:
           description: >-
-            the input was somehow invalid; probably missing username
+            Authorization header or token failed to validate (authentication error)
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserError'
+                $ref: '#/components/schemas/Unauthenticated'
     post:
       tags:
         - auth
       description: >-
         Return a mapping from the resources the specified user can access, to
-        the actions which they are authorized for on those resources.
+        the actions which they are authorized for on those resources. This includes
+        the mappings available to members of the `anonymous` and `logged-in` groups, 
+        which apply to all users (anonymous) and to all logged-in users (logged-in). 
+
+
+        If the specified user is not recognized by arborist, this endpoint returns
+        ONLY the mappings available to members of the `anonymous` and `logged-in` groups.
+
       requestBody:
+
         content:
           application/json:
             schema:
@@ -125,13 +155,33 @@ paths:
       description: >-
         Given a user token in the Authorization header, return a list of
         resources which are accessible to the user (using any action) according
-        to the policies listed in the token.
+        to the policies listed in the token. This includes the resources available 
+        to members of the `anonymous` and `logged-in` groups, which apply to all users 
+        (anonymous) and to all logged-in users (logged-in).
+
+
+        If the specified user is not recognized by arborist, this endpoint returns
+        ONLY the resources available to members of the `anonymous` and `logged-in` groups.
+
+
+        If no username is provided (i.e., if no token is provided in the Authorization header)
+        this endpoint returns ONLY the resources available to members of the `anonymous` group.
+
+
+        If the `?tags` query string parameter is passed, this endpoint returns the resource
+        tags for the resources, not the resources themselves.
       parameters:
         - in: header
           name: Authorization
           schema:
             type: string
           required: true
+        - in: query
+          name: tags
+          required: false
+          schema:
+            type: string
+          description: Instructs the endpoint to return resource tags instead of resources.
       responses:
         200:
           description: >-
@@ -151,9 +201,26 @@ paths:
       tags:
         - auth
       description: >-
-        Given a user token, return a list of resources which are accessible to
-        the user (using any action) according to the policies listed in the
-        token.
+        Given a user token in the body of the request, return a list of
+        resources which are accessible to the user (using any action) according
+        to the policies listed in the token. This includes the resources available 
+        to members of the `anonymous` and `logged-in` groups, which apply to all users 
+        (anonymous) and to all logged-in users (logged-in).
+
+
+        If the specified user is not recognized by arborist, this endpoint returns
+        ONLY the resources available to members of the `anonymous` and `logged-in` groups.
+
+
+        If the `?tags` query string parameter is passed, this endpoint returns the resource
+        tags for the resources, not the resources themselves.
+      parameters:
+        - in: query
+          name: tags
+          required: false
+          schema:
+            type: string
+          description: Instructs the endpoint to return resource tags instead of resources.
       requestBody:
         content:
           application/json:
@@ -654,7 +721,7 @@ paths:
       tags:
         - user
       description: >-
-        Read the information for a specific user.
+        Read the information for a specific user. 
       responses:
         200:
           description: user information
@@ -729,6 +796,28 @@ paths:
       responses:
         204:
           description: successfully revoked
+        404:
+          description: user not found
+  /user/{username}/resources:
+    parameters:
+      - in: path
+        name: username
+        required: true
+        schema:
+          type: string
+        description: the username for a user registered in arborist
+    get:
+      tags:
+        - user
+      description: >-
+        Returns the resources available to a specific user. 
+      responses:
+        200:
+          description: Resources available to this user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
         404:
           description: user not found
   /client:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Arborist
-  version: 2.3.2
+  version: 2.4.0
   description: authorization microservice to handle ABAC based on configured policies
   license:
     name: 'Apache 2.0'
@@ -817,7 +817,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/AuthResourcesResponse'
         404:
           description: user not found
   /client:

--- a/docs/username.md
+++ b/docs/username.md
@@ -2,8 +2,6 @@
 
 This document describes how Arborist should behave when the user is or is not known to Arborist.
 
-(Note: As of 2019-Nov-13 this is not yet how Arborist _actually_ behaves.)
-
 ## Context
 
 Arborist always has 2 default groups:

--- a/docs/username.md
+++ b/docs/username.md
@@ -22,14 +22,18 @@ The `user/...` endpoints are part of an admin-facing API, so returning a 404 err
 
 If we need the list of anonymous or logged-in policies, we can hit the `group/{groupname}` endpoint.
 
-## GET, POST auth/mapping and GET auth/resources endpoints
+## GET, POST auth/mapping and GET, POST auth/resources endpoints
 
-The `auth/mapping` endpoint accepts a username as an optional query parameter. If the username is not specified, we try to get it from the JWT. The `auth/resources` endpoints only uses the JWT.
+The GET `auth/mapping` endpoint accepts a username as an optional query parameter. If the username is not specified, we try to get it from the JWT in the 'Authorization' header.
+The GET `auth/resources` endpoint only passes the username in a JWT in the 'Authorization' header. 
+The POST `auth/mapping` and POST `auth/resources` endpoints pass the username in the request body.
 
 These endpoints return everything the user has access to, including anonymous and logged-in policies, following this logic:
 - Username is specified and it is in Arborist's database: return user's policies + anonymous and logged-in policies.
 - Username is specified but it is not in Arborist's database: return anonymous and logged-in policies.
-- No username can be found: return the anonymous policies.
+
+Additionally, the GET auth/mapping and GET auth/resources endpoints have this behavior:
+- No username provided (I.e., no username provided in query string, and no JWT is passed in the Authorization header): return anonymous policies only.
 
 >Background: Originally `auth/mapping` only took the username from a query parameter. Then the revproxy needed to expose the endpoint so that Windmill could hit it. But we couldn't allow users to hit `auth/mapping` with arbitrary usernames. So the revproxy does not forward any query parameters, and we added the JWT fallback in Arborist.
 


### PR DESCRIPTION
Changes behavior of Arborist endpoints to return the policies of the `anonymous` and `logged-in` groups for requests based on the spec in `docs/username.md`.  Fixes https://github.com/uc-cdis/arborist/issues/113.

Changes behavior of GET, POST `auth/resources`, GET, POST `auth/mapping`, and GET `user/resources` endpoints.

### New Features
- Arborist endpoints now return the policies of the `anonymous` and `logged-in` groups  based on the spec in `docs/username.md`. 

### Breaking Changes


### Bug Fixes


### Improvements
- Debugged Arborist unit tests and improved test coverage.
- Updated Arborist Swagger API documentation.

### Dependency updates


### Deployment changes

