### PR TITLE
Feat/put role

### DIFF
--- a/arborist/role.go
+++ b/arborist/role.go
@@ -210,6 +210,10 @@ func (role *Role) createInDb(db *sqlx.DB) *ErrorResponse {
 	return nil
 }
 
+func (role *Role) overwriteInDb(db *sqlx.DB) *ErrorResponse {
+	return nil
+}
+
 func (role *Role) deleteInDb(db *sqlx.DB) *ErrorResponse {
 	stmt := "DELETE FROM role WHERE name = $1"
 	_, err := db.Exec(stmt, role.Name)

--- a/arborist/role.go
+++ b/arborist/role.go
@@ -245,9 +245,9 @@ func (role *Role) overwriteInDb(db *sqlx.DB) *ErrorResponse {
 		VALUES ($1, $2, $3, $4, $5, $6)
 		ON CONFLICT(role_id, name) DO UPDATE
 		SET 
-			service     = $3
-			method      = $4
-			constraints = $5
+			service     = $3,
+			method      = $4,
+			constraints = $5,
 			description = $6
 	`
 	for _, permission := range role.Permissions {

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -123,7 +123,7 @@ func (server *Server) MakeRouter(out io.Writer) http.Handler {
 	router.Handle("/role/{roleID}", http.HandlerFunc(server.handleRoleRead)).Methods("GET")
 
 	// new "update role" endpoint
-	router.Handle("/role/{roleID}", http.HandlerFunc(server.handleRoleUpdate)).Methods("PUT")
+	router.Handle("/role/{roleID}", http.HandlerFunc(server.handleRoleOverwrite)).Methods("PUT")
 
 	router.Handle("/role/{roleID}", http.HandlerFunc(server.handleRoleDelete)).Methods("DELETE")
 
@@ -946,7 +946,7 @@ func (server *Server) handleRoleRead(w http.ResponseWriter, r *http.Request) {
 // or creates it if it doesn't already exist
 //
 // http response codes reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT
-func (server *Server) handleRoleUpdate(w http.ResponseWriter, r *http.Request) {
+func (server *Server) handleRoleOverwrite(w http.ResponseWriter, r *http.Request) {
 
 	// extract role name
 	name := mux.Vars(r)["roleID"]

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -942,16 +942,12 @@ func (server *Server) handleRoleRead(w http.ResponseWriter, r *http.Request) {
 }
 
 // new method for action "overwrite role"
-// updates existing role,
+// overwrites existing role,
 // or creates it if it doesn't already exist
 //
 // http response codes reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT
 func (server *Server) handleRoleOverwrite(w http.ResponseWriter, r *http.Request, body []byte) {
-
-	// extract role name
 	name := mux.Vars(r)["roleID"]
-
-	// query db for this role
 	roleFromQuery, err := roleWithName(server.db, name)
 	if err != nil {
 		msg := fmt.Sprintf("role query failed: %s", err.Error())
@@ -961,7 +957,6 @@ func (server *Server) handleRoleOverwrite(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// if it doesn't exist in the db, then create the role
 	if roleFromQuery == nil {
 		role := &Role{}
 		err := json.Unmarshal(body, role)
@@ -988,11 +983,8 @@ func (server *Server) handleRoleOverwrite(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// HERE - if it DOES exist in the db - update it
+	// HERE - overwrite existing role
 
-	// # from handleRoleRead()
-	// role := roleFromQuery.standardize()
-	// _ = jsonResponseFrom(role, http.StatusOK).write(w, r)
 }
 
 func (server *Server) handleRoleDelete(w http.ResponseWriter, r *http.Request) {

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -121,10 +121,7 @@ func (server *Server) MakeRouter(out io.Writer) http.Handler {
 	router.Handle("/role", http.HandlerFunc(server.handleRoleList)).Methods("GET")
 	router.Handle("/role", http.HandlerFunc(server.parseJSON(server.handleRoleCreate))).Methods("POST")
 	router.Handle("/role/{roleID}", http.HandlerFunc(server.handleRoleRead)).Methods("GET")
-
-	// new "overwrite role" endpoint
 	router.Handle("/role/{roleID}", http.HandlerFunc(server.parseJSON(server.handleRoleOverwrite))).Methods("PUT")
-
 	router.Handle("/role/{roleID}", http.HandlerFunc(server.handleRoleDelete)).Methods("DELETE")
 
 	router.Handle("/user", http.HandlerFunc(server.handleUserList)).Methods("GET")
@@ -941,7 +938,6 @@ func (server *Server) handleRoleRead(w http.ResponseWriter, r *http.Request) {
 	_ = jsonResponseFrom(role, http.StatusOK).write(w, r)
 }
 
-// new method for action "overwrite role"
 func (server *Server) handleRoleOverwrite(w http.ResponseWriter, r *http.Request, body []byte) {
 	name := mux.Vars(r)["roleID"]
 	roleFromQuery, err := roleWithName(server.db, name)
@@ -964,8 +960,6 @@ func (server *Server) handleRoleOverwrite(w http.ResponseWriter, r *http.Request
 	}
 
 	var errResponse *ErrorResponse
-
-	// role doesn't exist in db - create it
 	if roleFromQuery == nil {
 		errResponse = role.createInDb(server.db)
 		if errResponse != nil {
@@ -983,7 +977,6 @@ func (server *Server) handleRoleOverwrite(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// role exists in db - overwrite it
 	errResponse = role.overwriteInDb(server.db)
 	if errResponse != nil {
 		errResponse.log.write(server.logger)

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -123,7 +123,7 @@ func (server *Server) MakeRouter(out io.Writer) http.Handler {
 	router.Handle("/role/{roleID}", http.HandlerFunc(server.handleRoleRead)).Methods("GET")
 
 	// new "overwrite role" endpoint
-	router.Handle("/role/{roleID}", http.HandlerFunc(server.parseJSON(server.handleRoleOverwrite))).Methods("POST")
+	router.Handle("/role/{roleID}", http.HandlerFunc(server.parseJSON(server.handleRoleOverwrite))).Methods("PUT")
 
 	router.Handle("/role/{roleID}", http.HandlerFunc(server.handleRoleDelete)).Methods("DELETE")
 

--- a/arborist/server_test.go
+++ b/arborist/server_test.go
@@ -1165,6 +1165,9 @@ func TestServer(t *testing.T) {
 			assert.Equal(t, "foo", result.Name, msg)
 		})
 
+		// HERE - write test for new PUT /role/{role_name}
+		// t.Run("Overwrite", func(t *testing.T) {...})
+
 		t.Run("List", func(t *testing.T) {
 			w := httptest.NewRecorder()
 			req := newRequest("GET", "/role", nil)

--- a/arborist/server_test.go
+++ b/arborist/server_test.go
@@ -1226,7 +1226,7 @@ func TestServer(t *testing.T) {
 				httpError(t, w, "couldn't read response from roles list")
 			}
 			msg := fmt.Sprintf("got response body: %s", w.Body.String())
-			assert.Equal(t, 1, len(result.Roles), msg)
+			assert.Equal(t, 2, len(result.Roles), msg)
 		})
 
 		t.Run("Delete", func(t *testing.T) {

--- a/arborist/server_test.go
+++ b/arborist/server_test.go
@@ -1211,6 +1211,21 @@ func TestServer(t *testing.T) {
 			}
 		})
 
+		t.Run("FailOverwrite", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			body := []byte(`{
+				"id": "notFoo",
+				"permissions": [
+					{"id": "foo", "action": {"service": "*", "method": "bar"}}
+				]
+			}`)
+			req := newRequest("PUT", "/role/foo", bytes.NewBuffer(body))
+			handler.ServeHTTP(w, req)
+			if w.Code != http.StatusBadRequest {
+				httpError(t, w, "wrong response code from invalid role overwrite request")
+			}
+		})
+
 		t.Run("List", func(t *testing.T) {
 			w := httptest.NewRecorder()
 			req := newRequest("GET", "/role", nil)


### PR DESCRIPTION
problem: Previously Arborist did not have a PUT /role/{roleID} endpoint for overwriting existing roles, and this caused usersync to fail to modify existing roles. 

solution: Create a PUT /role/{roleID} endpoint for overwriting existing roles.

### New Features
- Implemented new PUT /role/{roleID} API endpoint for overwriting existing roles
