### PR TITLE
Remove duplicate UnderscoreDecode call

### DIFF
--- a/arborist/resource.go
+++ b/arborist/resource.go
@@ -137,7 +137,7 @@ func (resourceFromQuery *ResourceFromQuery) standardize() ResourceOut {
 	}
 	resource := ResourceOut{
 		Name:         UnderscoreDecode(resourceFromQuery.Name),
-		Path:         UnderscoreDecode(formatDbPath(resourceFromQuery.Path)),
+		Path:         formatDbPath(resourceFromQuery.Path),
 		Tag:          resourceFromQuery.Tag,
 		Subresources: subresources,
 	}


### PR DESCRIPTION
The `formatDbPath` function already contains a call to `UnderscoreDecode`. Being executed twice makes the decode wrong in the case where a new replacement case happens. Remove duplicate `UnderscoreDecode` call.

[Slack thread](https://cdis.slack.com/archives/CDDPLU1NU/p1603988739120700?thread_ts=1603856387.104700&cid=CDDPLU1NU)

### Bug Fixes
- Fix edge case causing wrong resource paths to be returned
