### PR TITLE
fix(may-release): Adopt parent img from quay to avoid pull rate limit errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine as build
+FROM quay.io/cdis/golang:1.12-alpine as build
 
 # Install SSL certificates
 RUN apk update && apk add --no-cache git ca-certificates gcc musl-dev jq curl bash postgresql


### PR DESCRIPTION
Address this issue:
```
Could not pull base image: API error (500): toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```