### PR TITLE
(PXP-8327): Account for expired policies and group users in Auth

### DIFF
--- a/arborist/auth.go
+++ b/arborist/auth.go
@@ -473,7 +473,9 @@ func authorizedResources(db *sqlx.DB, request *AuthRequest) ([]ResourceFromQuery
 			FROM resource
 			INNER JOIN policy_resource ON resource.id = policy_resource.resource_id
 			INNER JOIN usr_policy ON usr_policy.policy_id = policy_resource.policy_id
-			WHERE (policy_resource.policy_id IN (%s))
+			WHERE (policy_resource.policy_id IN (%s)) AND (
+				usr_policy.expires_at IS NULL OR NOW() < usr_policy.expires_at
+			)
 			`,
 			selectPolicyWhereName,
 		)
@@ -508,14 +510,14 @@ func authorizedResources(db *sqlx.DB, request *AuthRequest) ([]ResourceFromQuery
 				SELECT usr_policy.policy_id
 				FROM usr
 				JOIN usr_policy ON usr.id = usr_policy.usr_id
-				WHERE usr.name = $1
+				WHERE usr.name = $1 AND (usr_policy.expires_at IS NULL OR NOW() < usr_policy.expires_at)
 				UNION
 				SELECT grp_policy.policy_id
 				FROM grp
 				JOIN grp_policy ON grp_policy.grp_id = grp.id
 				JOIN usr_grp ON usr_grp.grp_id = grp.id
 				JOIN usr ON usr.id = usr_grp.usr_id
-				WHERE usr.name = $1
+				WHERE usr.name = $1 AND (usr_grp.expires_at IS NULL OR NOW() < usr_grp.expires_at)
 				UNION
 				SELECT grp_policy.policy_id
 				FROM grp
@@ -561,7 +563,7 @@ func authorizedResources(db *sqlx.DB, request *AuthRequest) ([]ResourceFromQuery
 				SELECT usr_policy.policy_id
 				FROM usr
 				JOIN usr_policy ON usr.id = usr_policy.usr_id
-				WHERE usr.name = $1
+				WHERE usr.name = $1 AND (usr_policy.expires_at IS NULL OR NOW() < usr_policy.expires_at)
 				UNION
 				SELECT client_policy.policy_id
 				FROM client
@@ -573,7 +575,7 @@ func authorizedResources(db *sqlx.DB, request *AuthRequest) ([]ResourceFromQuery
 				JOIN grp_policy ON grp_policy.grp_id = grp.id
 				JOIN usr_grp ON usr_grp.grp_id = grp.id
 				JOIN usr ON usr.id = usr_grp.usr_id
-				WHERE usr.name = $1
+				WHERE usr.name = $1 AND (usr_grp.expires_at IS NULL OR NOW() < usr_grp.expires_at)
 			) policies
 			LEFT JOIN policy_resource ON policy_resource.policy_id = policies.policy_id
 			INNER JOIN resource AS roots ON roots.id = policy_resource.resource_id

--- a/arborist/auth.go
+++ b/arborist/auth.go
@@ -664,12 +664,12 @@ func authMapping(db *sqlx.DB, username string) (AuthMapping, *ErrorResponse) {
 		(
 			SELECT usr_policy.policy_id FROM usr
 			INNER JOIN usr_policy ON usr_policy.usr_id = usr.id
-			WHERE usr.name = $1
+			WHERE usr.name = $1 AND (usr_policy.expires_at IS NULL OR NOW() < usr_policy.expires_at)
 			UNION
 			SELECT grp_policy.policy_id FROM usr
 			INNER JOIN usr_grp ON usr_grp.usr_id = usr.id
 			INNER JOIN grp_policy ON grp_policy.grp_id = usr_grp.grp_id
-			WHERE usr.name = $1
+			WHERE usr.name = $1 AND (usr_grp.expires_at IS NULL OR NOW() < usr_grp.expires_at)
 			UNION
 			SELECT grp_policy.policy_id FROM grp
 			INNER JOIN grp_policy ON grp_policy.grp_id = grp.id

--- a/arborist/auth.go
+++ b/arborist/auth.go
@@ -218,12 +218,12 @@ func authorizeUser(request *AuthRequest) (*AuthResponse, error) {
 				SELECT array_agg(resource.path) AS allowed FROM (
 					SELECT usr_policy.policy_id FROM usr
 					INNER JOIN usr_policy ON usr_policy.usr_id = usr.id
-					WHERE usr.name = $1 AND (usr_policy.expires_at IS NULL OR now() < usr_policy.expires_at)
+					WHERE usr.name = $1 AND (usr_policy.expires_at IS NULL OR NOW() < usr_policy.expires_at)
 					UNION
 					SELECT grp_policy.policy_id FROM usr
 					INNER JOIN usr_grp ON usr_grp.usr_id = usr.id
 					INNER JOIN grp_policy ON grp_policy.grp_id = usr_grp.grp_id
-					WHERE usr.name = $1
+					WHERE usr.name = $1 AND (usr_grp.expires_at IS NULL OR NOW() < usr_grp.expires_at)
 					UNION
 					SELECT grp_policy.policy_id FROM grp
 					INNER JOIN grp_policy ON grp_policy.grp_id = grp.id
@@ -262,12 +262,12 @@ func authorizeUser(request *AuthRequest) (*AuthResponse, error) {
 				SELECT array_agg(resource.path) AS allowed FROM (
 					SELECT usr_policy.policy_id FROM usr
 					INNER JOIN usr_policy ON usr_policy.usr_id = usr.id
-					WHERE usr.name = $1
+					WHERE usr.name = $1 AND (usr_policy.expires_at IS NULL OR NOW() < usr_policy.expires_at)
 					UNION
 					SELECT grp_policy.policy_id FROM usr
 					INNER JOIN usr_grp ON usr_grp.usr_id = usr.id
 					INNER JOIN grp_policy ON grp_policy.grp_id = usr_grp.grp_id
-					WHERE usr.name = $1
+					WHERE usr.name = $1 AND (usr_grp.expires_at IS NULL OR NOW() < usr_grp.expires_at)
 					UNION
 					SELECT grp_policy.policy_id FROM grp
 					INNER JOIN grp_policy ON grp_policy.grp_id = grp.id

--- a/arborist/auth.go
+++ b/arborist/auth.go
@@ -218,7 +218,7 @@ func authorizeUser(request *AuthRequest) (*AuthResponse, error) {
 				SELECT array_agg(resource.path) AS allowed FROM (
 					SELECT usr_policy.policy_id FROM usr
 					INNER JOIN usr_policy ON usr_policy.usr_id = usr.id
-					WHERE usr.name = $1
+					WHERE usr.name = $1 AND (usr_policy.expires_at IS NULL OR now() < usr_policy.expires_at)
 					UNION
 					SELECT grp_policy.policy_id FROM usr
 					INNER JOIN usr_grp ON usr_grp.usr_id = usr.id


### PR DESCRIPTION
The creation of expiring policies and group users was first supported in https://github.com/uc-cdis/arborist/pull/102.

This PR makes changes to the [Auth API](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/uc-cdis/arborist/master/docs/openapi.yaml#/auth) SQL statements to account for the window of time in between when a policy or group user expires and when `jobs/delete_expired_access` runs.

### Bug Fixes
- Account for expired policies and expired group users in Auth API endpoints

