### PR TITLE
PXP-8826 Support `expand` parameter in `GET /policy` endpoint

### DIFF
--- a/arborist/policy.go
+++ b/arborist/policy.go
@@ -17,9 +17,13 @@ type Policy struct {
 	RoleIDs       []string `json:"role_ids"`
 }
 
-type PolicyResource struct {
-	Policy   int64 `db:"policy_id"`
-	Resource int64 `db:"resource_id"`
+// expanded policies need their own struct so that unused RoleIDs/Roles
+// fields can be excluded from the JSON response
+type ExpandedPolicy struct {
+	Name          string   `json:"id"`
+	Description   string   `json:"description"`
+	ResourcePaths []string `json:"resource_paths"`
+	Roles         []Role   `json:"roles"`
 }
 
 // UnmarshalJSON defines the way that a `Policy` gets read when unmarshalling:

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -622,9 +622,7 @@ func (server *Server) handlePolicyList(w http.ResponseWriter, r *http.Request) {
 	for _, policyFromQuery := range policiesFromQuery {
 		policy := policyFromQuery.standardize()
 		policies = append(policies, policy)
-		for _, roleID := range(policy.RoleIDs) {
-			allPoliciesRoleIDs = append(allPoliciesRoleIDs, roleID)
-		}
+		allPoliciesRoleIDs = append(allPoliciesRoleIDs, policy.RoleIDs...)
 	}
 
 	// if `expand`, return expanded policies with role details

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -606,11 +606,8 @@ func (server *Server) makeAuthResourcesResponse(w http.ResponseWriter, r *http.R
 }
 
 func (server *Server) handlePolicyList(w http.ResponseWriter, r *http.Request) {
+	_, expandFlag := r.URL.Query()["expand"]
 	policiesFromQuery, err := listPoliciesFromDb(server.db)
-	policies := []Policy{}
-	for _, policyFromQuery := range policiesFromQuery {
-		policies = append(policies, policyFromQuery.standardize())
-	}
 	if err != nil {
 		msg := fmt.Sprintf("policies query failed: %s", err.Error())
 		errResponse := newErrorResponse(msg, 500, nil)
@@ -618,12 +615,67 @@ func (server *Server) handlePolicyList(w http.ResponseWriter, r *http.Request) {
 		_ = errResponse.write(w, r)
 		return
 	}
-	result := struct {
-		Policies []Policy `json:"policies"`
-	}{
-		Policies: policies,
+
+	// query policies
+	policies := []Policy{}
+	allPoliciesRoleIDs := []string{}
+	for _, policyFromQuery := range policiesFromQuery {
+		policy := policyFromQuery.standardize()
+		policies = append(policies, policy)
+		for _, roleID := range(policy.RoleIDs) {
+			allPoliciesRoleIDs = append(allPoliciesRoleIDs, roleID)
+		}
 	}
-	_ = jsonResponseFrom(result, http.StatusOK).write(w, r)
+
+	// if `expand`, return expanded policies with role details
+	expandedPolicies := []ExpandedPolicy{}
+	if expandFlag {
+		// query role details
+		roleMap := make(map[string]Role) // {role ID: role instance} map
+		rolesFromQuery, err := rolesWithNames(server.db, allPoliciesRoleIDs)
+		if err != nil {
+			msg := fmt.Sprintf("unable to list roles with IDs %v: %s", allPoliciesRoleIDs, err.Error())
+			errResponse := newErrorResponse(msg, 400, nil)
+			errResponse.log.write(server.logger)
+			_ = errResponse.write(w, r)
+			return
+		}
+		for _, roleFromQuery := range rolesFromQuery {
+			role := roleFromQuery.standardize()
+			roleMap[role.Name] = role
+		}
+
+		// generate expanded policies with role details
+		for _, policy := range policies {
+			expandedPolicy := ExpandedPolicy{
+				Name: policy.Name,
+				Description: policy.Description,
+				ResourcePaths: policy.ResourcePaths,
+			}
+			roles := []Role{}
+			for _, roleID := range policy.RoleIDs {
+				roles = append(roles, roleMap[roleID])
+			}
+			expandedPolicy.Roles = roles
+			expandedPolicies = append(expandedPolicies, expandedPolicy)
+		}
+
+		// return expanded policies
+		result := struct {
+			Policies []ExpandedPolicy `json:"policies"`
+		}{
+			Policies: expandedPolicies,
+		}
+		_ = jsonResponseFrom(result, http.StatusOK).write(w, r)
+	} else {
+		// return non-expanded policies
+		result := struct {
+			Policies []Policy `json:"policies"`
+		}{
+			Policies: policies,
+		}
+		_ = jsonResponseFrom(result, http.StatusOK).write(w, r)
+	}
 }
 
 func (server *Server) handlePolicyCreate(w http.ResponseWriter, r *http.Request, body []byte) {

--- a/arborist/server_test.go
+++ b/arborist/server_test.go
@@ -1496,7 +1496,7 @@ func TestServer(t *testing.T) {
 				httpError(t, w, "can't list policies")
 			}
 			result := struct {
-				Policies []interface{} `json:"policies"`
+				Policies []arborist.Policy `json:"policies"`
 			}{}
 			err = json.Unmarshal(w.Body.Bytes(), &result)
 			if err != nil {
@@ -1504,7 +1504,29 @@ func TestServer(t *testing.T) {
 			}
 			msg := fmt.Sprintf("got response body: %s", w.Body.String())
 			assert.Equal(t, 2, len(result.Policies), msg)
+			msg = fmt.Sprintf("non expanded policies should contain 'role_ids'. got response body: %s", w.Body.String())
+			assert.NotNil(t, result.Policies[0].RoleIDs, msg)
 			// TODO (rudyardrichter, 2019-04-15): more checks here on response
+		})
+
+		t.Run("ListExpanded", func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := newRequest("GET", "/policy?expand", nil)
+			handler.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				httpError(t, w, "can't list policies")
+			}
+			result := struct {
+				Policies []arborist.ExpandedPolicy `json:"policies"`
+			}{}
+			err = json.Unmarshal(w.Body.Bytes(), &result)
+			if err != nil {
+				httpError(t, w, "couldn't read response from policies list")
+			}
+			msg := fmt.Sprintf("got response body: %s", w.Body.String())
+			assert.Equal(t, 2, len(result.Policies), msg)
+			msg = fmt.Sprintf("expanded policies should contain 'roles'. got response body: %s", w.Body.String())
+			assert.NotNil(t, result.Policies[0].Roles, msg)
 		})
 
 		t.Run("Delete", func(t *testing.T) {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -800,6 +800,11 @@ paths:
         - user
       description: >-
         Create a new user
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
       responses:
         201:
           description: created user

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -452,7 +452,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Roles'
+                type: object
+                properties:
+                  roles:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Role'
     post:
       tags:
         - role
@@ -1439,15 +1444,6 @@ components:
           items:
             type: string
           example:  ["/programs/DEV-1", "/programs/DEV-2"]
-    Roles:
-      type: object
-      properties:
-        role_ids:
-          type: array
-          items:
-            type: string
-      example:
-        role_ids: ["create","upload","update","delete","file_uploader","read"]
     Role:
       type: object
       properties:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -591,6 +591,13 @@ paths:
         - policy
       description: >-
         List just the IDs for all policies which have been created in arborist.
+      parameters:
+        - in: path
+          name: expand
+          required: false
+          schema:
+            type: boolean
+          description: Whether to return detailed roles instead of only role IDs (disabled by default). If enabled, 'roles' will replace 'role_ids' in the returned data.
       responses:
         200:
           description: list of resources
@@ -599,12 +606,10 @@ paths:
               schema:
                 type: object
                 properties:
-                  policy_ids:
+                  policies:
                     type: array
                     items:
-                      type: string
-                example:
-                  policy_ids: ["programs.DEV-update","programs.DEV-delete","data_upload","programs.DEV-read","programs.DEV-create","programs.DEV-upload"]
+                      $ref: '#/components/schemas/Policy'
     post:
       tags:
         - policy


### PR DESCRIPTION
Jira Ticket: [PXP-8826](https://ctds-planx.atlassian.net/browse/PXP-8826)

### New Features
- Support `expand` parameter in `GET /policy` endpoint to get detailed roles instead of only role IDs

### Improvements
- Update `POST /user`, `GET /policy` and `GET /role` endpoints in API docs
