### PR TITLE
(PXP-9480): Support merge param for PUT /resource endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum",
     "lines": null
   },
-  "generated_at": "2021-11-29T14:09:22Z",
+  "generated_at": "2022-02-11T04:54:33Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -62,7 +62,7 @@
       {
         "hashed_secret": "f9fdc64928c96c7ad56bf7da557f70345d83a6ed",
         "is_verified": false,
-        "line_number": 1643,
+        "line_number": 1657,
         "type": "Base64 High Entropy String"
       }
     ],

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -864,7 +864,12 @@ func (server *Server) handleResourceCreate(w http.ResponseWriter, r *http.Reques
 
 	errResponse = nil
 	if r.Method == "PUT" {
-		errResponse = transactify(server.db, resource.overwriteInDb)
+		_, mergeFlag := r.URL.Query()["merge"]
+		updateResource := func(tx *sqlx.Tx) *ErrorResponse {
+			resource.updateInDb(tx, mergeFlag)
+			return nil
+		}
+		errResponse = transactify(server.db, updateResource)
 	} else {
 		errResponse = transactify(server.db, resource.createInDb)
 	}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -383,16 +383,14 @@ paths:
             schema:
               $ref: '#/components/schemas/ResourceInput'
       parameters:
-        - in: path
+        - in: query
           name: p
           description: >-
             Ordinarily arborist will return an error if parent resources of a
             resource you're trying to create do not exist yet. If the `p`
             parameter is included, it behaves like `mkdir -p` and creates all
             parent resources as necessary.
-          schema:
-            type: integer
-          required: true
+          required: false
       responses:
         201:
           description: JSON representation of successfully-created resource
@@ -421,6 +419,22 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ResourceInput'
+      parameters:
+        - in: query
+          name: p
+          description: >-
+            Ordinarily arborist will return an error if parent resources of a
+            resource you're trying to create do not exist yet. If the `p`
+            parameter is included, it behaves like `mkdir -p` and creates all
+            parent resources as necessary.
+          required: false
+        - in: query
+          name: merge
+          description: >-
+            Ordinarily arborist will overwrite the resource by deleting
+            existing subresources. If the `merge` parameter is included,
+            those existing subresources are not deleted.
+          required: false
       responses:
         201:
           description: JSON representation of successfully-updated resource


### PR DESCRIPTION
Jira Ticket: [PXP-9480](https://ctds-planx.atlassian.net/browse/PXP-9480)

As part of improving DRS endpoint performance, to enable creating multiple study resources with a single request **and** not have existing `/programs` subresources overwritten, support a `merge` param for the `PUT /resource` endpoint.

Corresponding PRs
- [Fence](url)
- [gen3authz](url)

### New Features
- Support `merge` param for `PUT /resource` endpoint so that existing subresources are not overwritten
