### PR TITLE
PXP-10113 Support "client credentials" tokens

### DIFF
--- a/arborist/server.go
+++ b/arborist/server.go
@@ -334,20 +334,31 @@ func (server *Server) handleAuthProxy(w http.ResponseWriter, r *http.Request) {
 	authRequest.stmts = server.stmts
 	w.Header().Set("REMOTE_USER", authRequest.Username)
 
-	rv, err := authorizeUser(authRequest)
-	if err != nil {
-		msg := fmt.Sprintf("could not authorize user: %s", err.Error())
-		server.logger.Info("tried to handle auth request but input was invalid: %s", msg)
-		response := newErrorResponse(msg, 400, nil)
-		_ = response.write(w, r)
+	if (authRequest.Username == "") && (authRequest.ClientID == "") {
+		msg := "unauthorized: did not provide a username and/or client ID in request"
+		_ = newErrorResponse(msg, 403, nil).write(w, r)
 		return
 	}
-	if rv.Auth {
-		server.logger.Debug("user is authorized")
-	} else {
-		server.logger.Debug("user is unauthorized")
+
+	rv := &AuthResponse{}
+	rv.Auth = true
+	var err error = nil
+	if authRequest.Username != "" {
+		rv, err = authorizeUser(authRequest)
+		if err != nil {
+			msg := fmt.Sprintf("could not authorize user: %s", err.Error())
+			server.logger.Info("tried to handle auth request but input was invalid: %s", msg)
+			response := newErrorResponse(msg, 400, nil)
+			_ = response.write(w, r)
+			return
+		}
+		if rv.Auth {
+			server.logger.Debug("user is authorized")
+		} else {
+			server.logger.Debug("user is unauthorized")
+		}
 	}
-	if err == nil && rv.Auth && authRequest.ClientID != "" {
+	if rv.Auth && authRequest.ClientID != "" {
 		rv, err = authorizeClient(authRequest)
 		if err != nil {
 			msg := fmt.Sprintf("could not authorize client: %s", err.Error())
@@ -455,9 +466,15 @@ func (server *Server) handleAuthRequest(w http.ResponseWriter, r *http.Request, 
 			continue
 		}
 
-		if (username == "") && (info.policies == nil || len(info.policies) == 0) {
-			msg := "missing both username and policies in request (at least one is required)"
+		if (clientID == "") && (username == "") && (info.policies == nil || len(info.policies) == 0) {
+			msg := "missing both username and policies in request (at least one is required when no client ID is provided)"
 			_ = newErrorResponse(msg, 400, nil).write(w, r)
+			return
+		}
+
+		if (username == "") && (clientID == "") {
+			msg := "unauthorized: did not provide a username and/or client ID in request"
+			_ = newErrorResponse(msg, 403, nil).write(w, r)
 			return
 		}
 
@@ -472,18 +489,22 @@ func (server *Server) handleAuthRequest(w http.ResponseWriter, r *http.Request, 
 			stmts:    server.stmts,
 		}
 		server.logger.Info("handling auth request: %#v", *request)
-		rv, err := authorizeUser(request)
-		if err != nil {
-			msg := fmt.Sprintf("could not authorize user: %s", err.Error())
-			server.logger.Info("tried to handle auth request but input was invalid: %s", msg)
-			response := newErrorResponse(msg, 400, nil)
-			_ = response.write(w, r)
-			return
-		}
-		if rv.Auth {
-			server.logger.Debug("user is authorized")
-		} else {
-			server.logger.Debug("user is unauthorized")
+		rv := &AuthResponse{}
+		rv.Auth = true
+		if request.Username != "" {
+			rv, err = authorizeUser(request)
+			if err != nil {
+				msg := fmt.Sprintf("could not authorize user: %s", err.Error())
+				server.logger.Info("tried to handle auth request but input was invalid: %s", msg)
+				response := newErrorResponse(msg, 400, nil)
+				_ = response.write(w, r)
+				return
+			}
+			if rv.Auth {
+				server.logger.Debug("user is authorized")
+			} else {
+				server.logger.Debug("user is unauthorized")
+			}
 		}
 		if rv.Auth && request.ClientID != "" {
 			rv, err = authorizeClient(request)
@@ -492,13 +513,13 @@ func (server *Server) handleAuthRequest(w http.ResponseWriter, r *http.Request, 
 			} else {
 				server.logger.Debug("client is unauthorized")
 			}
-		}
-		if err != nil {
-			msg := fmt.Sprintf("could not authorize client: %s", err.Error())
-			server.logger.Info("tried to handle auth request but input was invalid: %s", msg)
-			response := newErrorResponse(msg, 400, nil)
-			_ = response.write(w, r)
-			return
+			if err != nil {
+				msg := fmt.Sprintf("could not authorize client: %s", err.Error())
+				server.logger.Info("tried to handle auth request but input was invalid: %s", msg)
+				response := newErrorResponse(msg, 400, nil)
+				_ = response.write(w, r)
+				return
+			}
 		}
 		if !rv.Auth {
 			_ = jsonResponseFrom(rv, 200).write(w, r)
@@ -1504,6 +1525,7 @@ func (server *Server) handleClientGrantPolicy(w http.ResponseWriter, r *http.Req
 		_ = response.write(w, r)
 		return
 	}
+	server.logger.Info("attempting to grant policy %s to client %s", requestPolicy.PolicyName, clientID)
 	errResponse := grantClientPolicy(server.db, clientID, requestPolicy.PolicyName, getAuthZProvider(r))
 	if errResponse != nil {
 		errResponse.log.write(server.logger)

--- a/arborist/server_test.go
+++ b/arborist/server_test.go
@@ -85,22 +85,35 @@ func (testJWT *TestJWT) Encode() string {
 	}
 	var payload []byte
 	if testJWT.policies == nil || len(testJWT.policies) == 0 {
-		payload = []byte(fmt.Sprintf(
-			`{
-				"scope": ["openid"],
-				"exp": %d,
-				"sub": "0",
-				"context": {
-					"user": {
-						"name": "%s"
-					}
-				},
-				"azp": "%s"
-			}`,
-			exp,
-			testJWT.username,
-			testJWT.clientID,
-		))
+		if testJWT.username != "" {
+			payload = []byte(fmt.Sprintf(
+				`{
+					"scope": ["openid"],
+					"exp": %d,
+					"sub": "0",
+					"context": {
+						"user": {
+							"name": "%s"
+						}
+					},
+					"azp": "%s"
+				}`,
+				exp,
+				testJWT.username,
+				testJWT.clientID,
+			))
+		} else { // client_credentials token
+			payload = []byte(fmt.Sprintf(
+				`{
+					"scope": ["openid"],
+					"exp": %d,
+					"context": {},
+					"azp": "%s"
+				}`,
+				exp,
+				testJWT.clientID,
+			))
+		}
 	} else {
 		policies := fmt.Sprintf(`["%s"]`, strings.Join(testJWT.policies, `", "`))
 		payload = []byte(fmt.Sprintf(
@@ -3347,7 +3360,6 @@ func TestServer(t *testing.T) {
 				if w.Code != http.StatusOK {
 					httpError(t, w, "auth request failed")
 				}
-				// request should fail
 				result = struct {
 					Auth bool `json:"auth"`
 				}{}
@@ -3357,6 +3369,42 @@ func TestServer(t *testing.T) {
 				}
 				msg = fmt.Sprintf("got response body: %s", w.Body.String())
 				assert.Equal(t, true, result.Auth, msg)
+			})
+
+			t.Run("ClientOnlyOK", func(t *testing.T) {
+				w = httptest.NewRecorder()
+				token = TestJWT{clientID: clientID}
+				body = []byte(fmt.Sprintf(
+					`{
+						"user": {"token": "%s"},
+						"request": {
+							"resource": "%s",
+							"action": {
+								"service": "%s",
+								"method": "%s"
+							}
+						}
+					}`,
+					token.Encode(),
+					resourcePath,
+					serviceName,
+					methodName,
+				))
+				req = newRequest("POST", "/auth/request", bytes.NewBuffer(body))
+				handler.ServeHTTP(w, req)
+				if w.Code != http.StatusOK {
+					httpError(t, w, "auth request failed")
+				}
+				result = struct {
+					Auth bool `json:"auth"`
+				}{}
+				err = json.Unmarshal(w.Body.Bytes(), &result)
+				if err != nil {
+					httpError(t, w, "couldn't read response from auth request")
+				}
+				if result.Auth != true {
+					httpError(t, w, "auth request failed")
+				}
 			})
 
 			t.Run("QueryUsingUserID", func(t *testing.T) {
@@ -4491,6 +4539,23 @@ func TestServer(t *testing.T) {
 					)
 					req := newRequest("GET", authUrl, nil)
 					token := TestJWT{username: username, clientID: clientID}
+					req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token.Encode()))
+					handler.ServeHTTP(w, req)
+					if w.Code != http.StatusOK {
+						httpError(t, w, "auth proxy request failed")
+					}
+				})
+
+				t.Run("ClientOnlyGranted", func(t *testing.T) {
+					w := httptest.NewRecorder()
+					authUrl := fmt.Sprintf(
+						"/auth/proxy?resource=%s&service=%s&method=%s",
+						url.QueryEscape(resourcePath),
+						url.QueryEscape(serviceName),
+						url.QueryEscape(methodName),
+					)
+					req := newRequest("GET", authUrl, nil)
+					token := TestJWT{clientID: clientID}
 					req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token.Encode()))
 					handler.ServeHTTP(w, req)
 					if w.Code != http.StatusOK {

--- a/arborist/token.go
+++ b/arborist/token.go
@@ -46,38 +46,39 @@ func (server *Server) decodeToken(token string, scopes []string) (*TokenInfo, er
 	if !casted {
 		return nil, fieldTypeError("context")
 	}
-	userInterface, exists := context["user"]
-	if !exists {
-		return nil, missingRequiredField("user")
-	}
-	user, casted := userInterface.(map[string]interface{})
-	if !casted {
-		return nil, fieldTypeError("user")
-	}
-	usernameInterface, exists := user["name"]
-	if !exists {
-		return nil, missingRequiredField("name")
-	}
-	username, casted := usernameInterface.(string)
-	if !casted {
-		return nil, fieldTypeError("name")
-	}
-	policiesInterface, exists := user["policies"]
+	username := ""
 	var policies []string = nil
-	// it's ok if there's no policies in the token; we'll just look up the username
+	userInterface, exists := context["user"]
+	// it's ok if there's no user; it's a client credentials token
 	if exists {
-		// policiesInterface should really be a []string, so cast all the elements
-		policiesInterfaceSlice, casted := policiesInterface.([]interface{})
+		user, casted := userInterface.(map[string]interface{})
 		if !casted {
-			return nil, fieldTypeError("policies")
+			return nil, fieldTypeError("user")
 		}
-		policies := make([]string, len(policiesInterfaceSlice))
-		for i, policyInterface := range policiesInterfaceSlice {
-			policyString, casted := policyInterface.(string)
+		usernameInterface, exists := user["name"]
+		if !exists {
+			return nil, missingRequiredField("name")
+		}
+		username, casted = usernameInterface.(string)
+		if !casted {
+			return nil, fieldTypeError("name")
+		}
+		policiesInterface, exists := user["policies"]
+		// it's ok if there's no policies in the token; we'll just look up the username
+		if exists {
+			// policiesInterface should really be a []string, so cast all the elements
+			policiesInterfaceSlice, casted := policiesInterface.([]interface{})
 			if !casted {
 				return nil, fieldTypeError("policies")
 			}
-			policies[i] = policyString
+			policies := make([]string, len(policiesInterfaceSlice))
+			for i, policyInterface := range policiesInterfaceSlice {
+				policyString, casted := policyInterface.(string)
+				if !casted {
+					return nil, fieldTypeError("policies")
+				}
+				policies[i] = policyString
+			}
 		}
 	}
 	clientID := ""


### PR DESCRIPTION
Jira Ticket: [PXP-10113](https://ctds-planx.atlassian.net/browse/PXP-10113)

⚠️ "Client credentials" tokens are not supported by all endpoints, only by the ones needed for the driving use cases

### New Features
- Support "client credentials" tokens that are not linked to a user in the `/auth/request` and `/auth/proxy` endpoints
