### PR TITLE
Fix misleading `/auth/proxy` docs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-10-06T20:50:53Z",
+  "generated_at": "2023-01-31T20:54:41Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -70,7 +70,7 @@
       {
         "hashed_secret": "f9fdc64928c96c7ad56bf7da557f70345d83a6ed",
         "is_verified": false,
-        "line_number": 1658,
+        "line_number": 1665,
         "type": "Base64 High Entropy String"
       }
     ],

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -123,11 +123,16 @@ paths:
         basic set of operations one might expect in ABAC (read/write, etc.)
         combined with the client service, and the path for the resource the user
         is trying to access.
+
+
         If using a list of `requests`, the response is positive if the user
         has access to ALL items in the list.
+
         If the given JWT has `azp` field, the permission of
         the corresponding client will be also checked; only when both the user
         and the client have permission can the response be positive. 
+
+
         IMPORTANT NOTE: Under `body` you can now also check authorization of 
         a user given just the username using the field `user_id` instead of 
         using `token`. This means that anyone can check anyone's authorization
@@ -147,7 +152,8 @@ paths:
             Arborist successfully returned an authorization decision. NOTE
             that a 200 status DOES NOT indicate authorization, only that the
             input was valid. The `"auth"` field in the response indicates
-            authorization.
+            authorization (this is different from
+            the `/auth/proxy` endpoint behavior).
           content:
             application/json:
               schema:
@@ -173,6 +179,8 @@ paths:
         basic set of operations one might expect in ABAC (read/write, etc.)
         combined with the client service, and the path for the resource the user
         is trying to access.
+
+
         If the given JWT has `azp` field, the permission of
         the corresponding client will be also checked; only when both the user
         and the client have permission can the response be positive.
@@ -196,9 +204,8 @@ paths:
         200:
           description: >-
             Arborist successfully returned an authorization decision. NOTE
-            that a 200 status DOES NOT indicate authorization, only that the
-            input was valid. The `"ok"` field in the response indicates
-            authorization.
+            that a 200 status DOES indicate authorization (this is different from
+            the `/auth/request` endpoint behavior).
         400:
           description: >-
             The input was somehow invalid; for example, a given resource does


### PR DESCRIPTION
relates to https://github.com/uc-cdis/data-portal/pull/1220
### Improvements
- Fix misleading `/auth/proxy` endpoint documentation. The endpoint does not return an `ok` field
