### PR TITLE
Add POST /auth/mapping token validation

### DIFF
--- a/arborist/server.go
+++ b/arborist/server.go
@@ -281,12 +281,15 @@ func (server *Server) handleAuthMappingPOST(w http.ResponseWriter, r *http.Reque
 		ClientID string  `json:"clientID"`
 	}{}
 
-	// Try to get username from the JWT.
+	// Try to get username or clientID from the JWT.
 	username := ""
 	clientID := ""
 	if authHeader := r.Header.Get("Authorization"); authHeader != "" {
 		server.logger.Info("Attempting to get username or clientID from jwt...")
+
+		// TODO remove
 		server.logger.Info("header: %s", authHeader)
+
 		userJWT := strings.TrimPrefix(authHeader, "Bearer ")
 		userJWT = strings.TrimPrefix(userJWT, "bearer ")
 		scopes := []string{"openid"}
@@ -297,14 +300,16 @@ func (server *Server) handleAuthMappingPOST(w http.ResponseWriter, r *http.Reque
 			server.logger.Info(msg)
 			errResponse = newErrorResponse(msg, 400, nil)
 		} else {
+
+			// TODO add logic in the print
 			username = info.username
 			clientID = info.clientID
 			server.logger.Info("found username in jwt: %s", username)
 			server.logger.Info("found clientID in jwt: %s", clientID)
-			
 		}
 	}
 
+	// If they are not present in the token fallback on the request body
 	if (username == "") && (clientID == "") {
 		err := json.Unmarshal(body, &requestBody)
 		if err != nil {
@@ -312,6 +317,8 @@ func (server *Server) handleAuthMappingPOST(w http.ResponseWriter, r *http.Reque
 			server.logger.Info("tried to handle auth mapping request but input was invalid: %s", msg)
 			errResponse = newErrorResponse(msg, 400, nil)
 		} else {
+
+			// TODO remove
 			server.logger.Info("client in body: %s", requestBody.ClientID)
 			server.logger.Info("user in body: %s", requestBody.Username)
 

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -280,16 +280,44 @@ func (server *Server) handleAuthMappingPOST(w http.ResponseWriter, r *http.Reque
 		Username string `json:"username"`
 		ClientID string  `json:"clientID"`
 	}{}
-	err := json.Unmarshal(body, &requestBody)
-	if err != nil {
-		msg := fmt.Sprintf("could not parse JSON: %s", err.Error())
-		server.logger.Info("tried to handle auth mapping request but input was invalid: %s", msg)
-		errResponse = newErrorResponse(msg, 400, nil)
+
+	// Try to get username from the JWT.
+	username := ""
+	clientID := ""
+	if authHeader := r.Header.Get("Authorization"); authHeader != "" {
+		server.logger.Info("Attempting to get username or clientID from jwt...")
+		userJWT := strings.TrimPrefix(authHeader, "Bearer ")
+		userJWT = strings.TrimPrefix(userJWT, "bearer ")
+		scopes := []string{"openid"}
+		info, err := server.decodeToken(userJWT, scopes)
+		if err != nil {
+			// Return 400 on failure to decode JWT
+			msg := fmt.Sprintf("tried to get username/clientID from jwt, but jwt decode failed: %s", err.Error())
+			server.logger.Info(msg)
+			errResponse = newErrorResponse(msg, 400, nil)
+		}
+		server.logger.Info("found username in jwt: %s", info.username)
+		username = info.username
+		clientID = info.clientID
 	}
-	if (requestBody.Username == "") == (requestBody.ClientID == "") {
-		msg := "must specify exactly one of `username` or `clientID`"
-		server.logger.Info(msg)
-		errResponse = newErrorResponse(msg, 400, nil)
+	if errResponse == nil {
+		err := json.Unmarshal(body, &requestBody)
+		if err != nil {
+			msg := fmt.Sprintf("could not parse JSON: %s", err.Error())
+			server.logger.Info("tried to handle auth mapping request but input was invalid: %s", msg)
+			errResponse = newErrorResponse(msg, 400, nil)
+		} else {
+			if (requestBody.Username == "") == (requestBody.ClientID == "") {
+				msg := "must specify exactly one of `username` or `clientID`"
+				server.logger.Info(msg)
+				errResponse = newErrorResponse(msg, 400, nil)
+			}
+			if (requestBody.Username != username) || (requestBody.ClientID != clientID) {
+				msg := "The information provided in the payload differs from the one extracted from the token."
+				server.logger.Info(msg)
+				errResponse = newErrorResponse(msg, 400, nil)
+			}
+		}
 	}
 	if errResponse != nil {
 		_ = errResponse.write(w, r)
@@ -298,9 +326,9 @@ func (server *Server) handleAuthMappingPOST(w http.ResponseWriter, r *http.Reque
 
 	var mappings AuthMapping
 	if requestBody.ClientID != "" {
-		mappings, errResponse = authMappingForClient(server.db, requestBody.ClientID)
+		mappings, errResponse = authMappingForClient(server.db, clientID)
 	} else {
-		mappings, errResponse = authMapping(server.db, requestBody.Username)
+		mappings, errResponse = authMapping(server.db, username)
 	}
 	if errResponse != nil {
 		errResponse.log.write(server.logger)

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -329,7 +329,7 @@ func (server *Server) handleAuthMappingPOST(w http.ResponseWriter, r *http.Reque
 			}
 
 			if requestBody.ClientID != "" {
-				ClientID = requestBody.ClientID
+				clientID = requestBody.ClientID
 			} else {
 				username = requestBody.Username
 			}
@@ -342,7 +342,7 @@ func (server *Server) handleAuthMappingPOST(w http.ResponseWriter, r *http.Reque
 	}
 
 	var mappings AuthMapping
-	if ClientID != "" {
+	if clientID != "" {
 		mappings, errResponse = authMappingForClient(server.db, clientID)
 	} else {
 		mappings, errResponse = authMapping(server.db, username)

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -287,9 +287,6 @@ func (server *Server) handleAuthMappingPOST(w http.ResponseWriter, r *http.Reque
 	if authHeader := r.Header.Get("Authorization"); authHeader != "" {
 		server.logger.Info("Attempting to get username or clientID from jwt...")
 
-		// TODO remove
-		server.logger.Info("header: %s", authHeader)
-
 		userJWT := strings.TrimPrefix(authHeader, "Bearer ")
 		userJWT = strings.TrimPrefix(userJWT, "bearer ")
 		scopes := []string{"openid"}
@@ -300,12 +297,14 @@ func (server *Server) handleAuthMappingPOST(w http.ResponseWriter, r *http.Reque
 			server.logger.Info(msg)
 			errResponse = newErrorResponse(msg, 400, nil)
 		} else {
-
-			// TODO add logic in the print
 			username = info.username
 			clientID = info.clientID
-			server.logger.Info("found username in jwt: %s", username)
-			server.logger.Info("found clientID in jwt: %s", clientID)
+			if username != "" {
+				server.logger.Info("found username in jwt: %s", username)
+			}
+			if clientID != "" {
+				server.logger.Info("found clientID in jwt: %s", clientID)
+			}
 		}
 	}
 
@@ -317,11 +316,6 @@ func (server *Server) handleAuthMappingPOST(w http.ResponseWriter, r *http.Reque
 			server.logger.Info("tried to handle auth mapping request but input was invalid: %s", msg)
 			errResponse = newErrorResponse(msg, 400, nil)
 		} else {
-
-			// TODO remove
-			server.logger.Info("client in body: %s", requestBody.ClientID)
-			server.logger.Info("user in body: %s", requestBody.Username)
-
 			if (requestBody.Username == "") == (requestBody.ClientID == "") {
 				msg := "must specify exactly one of `username` or `clientID`"
 				server.logger.Info(msg)


### PR DESCRIPTION
Jira Ticket: [PXP-xxxx](https://ctds-planx.atlassian.net/browse/PXP-xxxx)
- [ ] Remove this line if you've changed the title to (PXP-xxxx): <title>
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features
This PR extend the POST endpoint for /auth/mapping to validate the token received. The behavior is the following:
- no token only body  (just check for clientID or username in the payload as it was previously)
- token and no body (token validation and extract the clientID/username from the token)
- none of them (error)
- both of them (token takes priority and the body is skipped)

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
