### PR TITLE
PPS-742 Update x/net through x/crypto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
+	golang.org/x/crypto v0.19.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/uc-cdis/go-authutils v0.1.2 h1:ts9Q1jHs0YIzeErZ6MAsbTrQwfNL4RjE9Wcx/+
 github.com/uc-cdis/go-authutils v0.1.2/go.mod h1:NT4wNQiGGq9K/vhZoaJQmPwmTAQXz+haWSBB5QyL4Mc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 h1:7I4JAnoQBe7ZtJcBaYHi5UtiO8tQHbUSXxL+pnGRANg=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.19.0 h1:ENy+Az/9Y1vSrlrvBSyna3PITt4tiZLf7sgCjZBX7Wo=
+golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Jira Ticket: [PPS-742](https://ctds-planx.atlassian.net/browse/PPS-742)

Closes #158

```
Before:
$ go list -m all | grep x/net
golang.org/x/net v0.0.0-20210226172049-e18ecbb05110

After:
$ go list -m all | grep x/net
golang.org/x/net v0.10.0
```

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates
- `x/crypto` to version 0.19.0, `x/net` to version 0.10.0

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->


[PPS-742]: https://ctds-planx.atlassian.net/browse/PPS-742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ