### PR TITLE
PXP-11248 PXP-11258 "POST /auth/mapping" anonymous support

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-03-01T20:51:33Z",
+  "generated_at": "2024-03-11T21:41:11Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -70,7 +70,7 @@
       {
         "hashed_secret": "f9fdc64928c96c7ad56bf7da557f70345d83a6ed",
         "is_verified": false,
-        "line_number": 1684,
+        "line_number": 1688,
         "type": "Base64 High Entropy String"
       }
     ],

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -301,7 +301,7 @@ func (server *Server) handleAuthMappingPOST(w http.ResponseWriter, r *http.Reque
 		_ = err.write(w, r)
 		return
 	}
-	if body != nil {
+	if len(body) > 0 {
 		// Try to get username or clientID from the request body
 		server.logger.Info("Attempting to get username and client ID from request body...")
 		err := json.Unmarshal(body, &requestBody)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -30,7 +30,7 @@ paths:
         Note: Tokens which are linked to both a user and a client (token belonging to a client acting on behalf of a user) are supported, but the client's access is NOT taken into account. Only the user's access is returned.
 
 
-        Note that this endpoint does NOT support tokens generated through the OIDC "client_credentials" grant, which are linked to a client but not to a user. Calling this endpoint with such a token will not return the client's access.
+        Note: This endpoint does NOT support tokens generated through the OIDC "client_credentials" grant, which are linked to a client but not to a user. Calling this endpoint with such a token will not return the client's access.
 
 
         If the specified user is not recognized by arborist, this endpoint returns
@@ -96,6 +96,10 @@ paths:
 
         If the specified client is not recognized by arborist, this endpoint returns
         an empty response.
+
+
+        If no username or client ID is provided (no token is provided in the Authorization header, and there is no request body),
+        this endpoint returns ONLY the mappings available to members of the `anonymous` group.
 
 
         Note: accepting a username or client ID in the body means that anyone can check anyone's authorization if they have their username. For this reason, this API is not meant to be exposed publicly.


### PR DESCRIPTION
Jira Tickets: [PXP-11248](https://ctds-planx.atlassian.net/browse/PXP-11248) and [PXP-11258](https://ctds-planx.atlassian.net/browse/PXP-11258)

Update to #163
Goes with https://github.com/uc-cdis/guppy/pull/254
Reason for this change: https://github.com/uc-cdis/guppy/pull/254#issuecomment-1983908970

----

Tested in QA - Arborist logs when logic from https://github.com/uc-cdis/guppy/pull/254 kicks in:
- Old or new arborist + old guppy (hits GET endpoint only):
```
- Authenticated call:
INFO: Attempting to get username from jwt...
DEBUG: decoding token: <redacted>
INFO: found username in jwt: <redacted>
"GET /auth/mapping HTTP/1.1" 200

- Anonymous call:
"GET /auth/mapping HTTP/1.1" 200
```
- Old arborist + new guppy (hits POST endpoint, falls back on GET endpoint):
```
- Authenticated call:
INFO: tried to handle auth mapping request but input was invalid: could not parse JSON: unexpected end of JSON input
INFO: must specify exactly one of `username` or `clientID`
"POST /auth/mapping HTTP/1.1" 400 87 "" "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
INFO: Attempting to get username from jwt...
DEBUG: decoding token: <redacted>
INFO: found username in jwt: <redacted>
"GET /auth/mapping HTTP/1.1" 200

- Anonymous call:
INFO: tried to handle auth mapping request but input was invalid: could not parse JSON: unexpected end of JSON input
INFO: must specify exactly one of `username` or `clientID`
"POST /auth/mapping HTTP/1.1" 400
"GET /auth/mapping HTTP/1.1" 200
```
- New arborist + new guppy (hits POST endpoint only):
```
- Authenticated call:
INFO: Attempting to get username or client ID from jwt...
DEBUG: decoding token: <redacted>
INFO: found username in jwt: <redacted>
"POST /auth/mapping HTTP/1.1" 200

- Anonymous call:
"POST /auth/mapping HTTP/1.1" 200
```

----

### New Features
- `POST /auth/mapping`: return "anonymous" access when the user is unauthenticated, matching the behavior of the `GET /auth/mapping` endpoint (previously the `POST` endpoint returned an error in this case)


[PXP-11248]: https://ctds-planx.atlassian.net/browse/PXP-11248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PXP-11258]: https://ctds-planx.atlassian.net/browse/PXP-11258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ