### PR TITLE
Support deleting users with a slash in their username

### DIFF
--- a/arborist/server.go
+++ b/arborist/server.go
@@ -133,7 +133,7 @@ func (server *Server) MakeRouter(out io.Writer) http.Handler {
 	router.Handle("/user", http.HandlerFunc(server.parseJSON(server.handleUserCreate))).Methods("POST")
 	router.Handle("/user/{username}", http.HandlerFunc(server.handleUserRead)).Methods("GET")
 	router.Handle("/user/{username}", http.HandlerFunc(server.parseJSON(server.handleUserUpdate))).Methods("PATCH")
-	router.Handle("/user/{username}", http.HandlerFunc(server.handleUserDelete)).Methods("DELETE")
+	router.Handle("/user/{username:.*}", http.HandlerFunc(server.handleUserDelete)).Methods("DELETE")
 	router.Handle("/user/{username}/policy", http.HandlerFunc(server.parseJSON(server.handleUserGrantPolicy))).Methods("POST")
 	router.Handle("/user/{username}/bulk/policy", http.HandlerFunc(server.parseJSON(server.handleBulkUserGrantPolicy))).Methods("POST") // NEW bulk grant policy
 	router.Handle("/user/{username}/policy", http.HandlerFunc(server.handleUserRevokeAll)).Methods("DELETE")

--- a/arborist/server.go
+++ b/arborist/server.go
@@ -133,12 +133,16 @@ func (server *Server) MakeRouter(out io.Writer) http.Handler {
 	router.Handle("/user", http.HandlerFunc(server.parseJSON(server.handleUserCreate))).Methods("POST")
 	router.Handle("/user/{username}", http.HandlerFunc(server.handleUserRead)).Methods("GET")
 	router.Handle("/user/{username}", http.HandlerFunc(server.parseJSON(server.handleUserUpdate))).Methods("PATCH")
-	router.Handle("/user/{username:.*}", http.HandlerFunc(server.handleUserDelete)).Methods("DELETE")
 	router.Handle("/user/{username}/policy", http.HandlerFunc(server.parseJSON(server.handleUserGrantPolicy))).Methods("POST")
-	router.Handle("/user/{username}/bulk/policy", http.HandlerFunc(server.parseJSON(server.handleBulkUserGrantPolicy))).Methods("POST") // NEW bulk grant policy
+	router.Handle("/user/{username}/bulk/policy", http.HandlerFunc(server.parseJSON(server.handleBulkUserGrantPolicy))).Methods("POST")
 	router.Handle("/user/{username}/policy", http.HandlerFunc(server.handleUserRevokeAll)).Methods("DELETE")
 	router.Handle("/user/{username}/policy/{policyName}", http.HandlerFunc(server.handleUserRevokePolicy)).Methods("DELETE")
 	router.Handle("/user/{username}/resources", http.HandlerFunc(server.handleUserListResources)).Methods("GET")
+	// Define this one last because `{username:.*}` matches any character, including slashes.
+	// Other `/user/{username}/xyz` routes must be defined first to be reachable.
+	// Slashes in usernames are not supported by all endpoints, but they should be supported here
+	// so the users can at least be deleted.
+	router.Handle("/user/{username:.*}", http.HandlerFunc(server.handleUserDelete)).Methods("DELETE")
 
 	router.Handle("/client", http.HandlerFunc(server.handleClientList)).Methods("GET")
 	router.Handle("/client", http.HandlerFunc(server.parseJSON(server.handleClientCreate))).Methods("POST")

--- a/arborist/server_test.go
+++ b/arborist/server_test.go
@@ -1750,6 +1750,30 @@ func TestServer(t *testing.T) {
 					httpError(t, w, "expected 400 from trying to create user without name")
 				}
 			})
+
+			t.Run("UsernameWithSlash", func(t *testing.T) {
+				w := httptest.NewRecorder()
+				body := []byte(fmt.Sprintf(
+					`{
+						"name": "username/withslash",
+						"email": "%s"
+					}`,
+					userEmail,
+				))
+				req := newRequest("POST", "/user", bytes.NewBuffer(body))
+				handler.ServeHTTP(w, req)
+				if w.Code != http.StatusCreated {
+					httpError(t, w, "couldn't create user")
+				}
+				result := struct {
+					I interface{} `json:"created"`
+				}{}
+				err = json.Unmarshal(w.Body.Bytes(), &result)
+				if err != nil {
+					httpError(t, w, "couldn't read response from user creation")
+				}
+			})
+
 		})
 
 		anonymousPolicies, anonymousResourcePaths, _ := setupAnonymousPolicies(t)
@@ -2159,6 +2183,15 @@ func TestServer(t *testing.T) {
 				handler.ServeHTTP(w, req)
 				if w.Code != http.StatusNoContent {
 					httpError(t, w, "expected 204 from trying to delete nonexistent user")
+				}
+			})
+
+			t.Run("UsernameWithSlash", func(t *testing.T) {
+				w := httptest.NewRecorder()
+				req := newRequest("DELETE", "/user/username/withslash", nil)
+				handler.ServeHTTP(w, req)
+				if w.Code != http.StatusNoContent {
+					httpError(t, w, "couldn't delete user")
 				}
 			})
 		})


### PR DESCRIPTION
Fix for this error:
```
could not delete user `vNFx/Hx6hbNsBL5ZZfSneJB41jU=`: not found
```

### New Features

### Breaking Changes

### Bug Fixes
- Support deleting users with a slash in their username

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
