### PR TITLE
Upgrade go-jose/v3 v3.0.4 -> v3.0.5 to fix CVE-2024-34986. Bumps Go f…

### DIFF
--- a/.github/workflows/golang-ci-workflow.yaml
+++ b/.github/workflows/golang-ci-workflow.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Run tests, lint code, install goveralls
         uses: uc-cdis/.github/.github/actions/golang-ci@master
         with:
-          GO_VERSION: "1.17"
+          GO_VERSION: "1.23"
           TESTS_LOCATION: ./arborist/
           COVERAGE_PROFILE_OUTPUT_LOCATION: ${{ env.COVERAGE_PROFILE_OUTPUT_LOCATION }}
           # TODO: reenable linting once arborist uses go 1.18+ and this error is fixed:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM quay.io/cdis/golang:1.17-bullseye AS build-deps
+FROM quay.io/cdis/golang:1.23-bookworm AS build-deps
 
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends jq=1.* postgresql=13* \
+    && apt-get install -y --no-install-recommends jq=1.* postgresql=15* \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/uc-cdis/arborist
 
-go 1.17
+go 1.23.0
 
 require (
-	github.com/go-jose/go-jose/v3 v3.0.4 // can be upgraded to v4 once we use go 1.21+. see https://github.com/uc-cdis/arborist/pull/181
+	github.com/go-jose/go-jose/v3 v3.0.5 // can be upgraded to v4 once we use go 1.21+. see https://github.com/uc-cdis/arborist/pull/181
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/jmoiron/sqlx v1.3.4

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
 github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/go-jose/go-jose/v3 v3.0.4 h1:Wp5HA7bLQcKnf6YYao/4kpRpVMp/yf6+pJKV8WFSaNY=
-github.com/go-jose/go-jose/v3 v3.0.4/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
+github.com/go-jose/go-jose/v3 v3.0.5 h1:BLLJWbC4nMZOfuPVxoZIxeYsn6Nl2r1fITaJ78UQlVQ=
+github.com/go-jose/go-jose/v3 v3.0.5/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
@@ -31,8 +31,6 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/uc-cdis/go-authutils v0.1.3-0.20251208205248-359bffa08b29 h1:N8i7B4yp9Bxj+QZ07hBAAVgh/d9ixQC2nLJFekZd1bM=
-github.com/uc-cdis/go-authutils v0.1.3-0.20251208205248-359bffa08b29/go.mod h1:yltnlkJAiTx42kFA7lHGO56gUl6n2MJT3s6LyX57rAo=
 github.com/uc-cdis/go-authutils v0.1.3-0.20251210162059-6e78e9723952 h1:LGY5D3llPGcfUJymb2HJyVkAaqMUTBvVISCeI21p+p0=
 github.com/uc-cdis/go-authutils v0.1.3-0.20251210162059-6e78e9723952/go.mod h1:yltnlkJAiTx42kFA7lHGO56gUl6n2MJT3s6LyX57rAo=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=


### PR DESCRIPTION
…rom 1.17 to 1.23. Required because: go-jose v3.0.5 uses bytes.Clone (Go 1.20+) and go-jose v3.0.5 depends on x/crypto v0.39.0 which requires Go 1.23. Also updates Dockerfilebase image from golang:1.17-bullseye to golang:1.23-bookworm and postgresql from 13 to 15 (bookworm ships 15).

<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one:

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
